### PR TITLE
Fix returning argument types from methods.

### DIFF
--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TESTS
 	WeakReferences_arc.m
 	objc_msgSend.m
 	msgInterpose.m
+	MethodArguments.m
 )
 
 # Function for adding a test.  This takes the name of the test and the list of

--- a/Test/MethodArguments.m
+++ b/Test/MethodArguments.m
@@ -1,0 +1,91 @@
+#import "Test.h"
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <malloc.h>
+
+#ifdef __has_attribute
+#if __has_attribute(objc_root_class)
+__attribute__((objc_root_class))
+#endif
+#endif
+@interface Foo
+-(id)bar;
+-(void)setBar:(id)b;
+@end 
+@implementation Foo
+- (id)bar
+{
+	return nil;
+}
+
+- (void)setBar: (id)b
+{
+	return;
+}
+@end
+
+int main(void)
+{
+	Class foo = objc_getClass("Foo");
+	Method barMethod = class_getInstanceMethod(foo, @selector(bar));
+	Method setBarMethod = class_getInstanceMethod(foo,@selector(setBar:));
+	char arg[16];
+
+	memset(&arg[0], '\0', 16 * sizeof(char));
+	method_getReturnType(barMethod, &arg[0], 16);
+	assert(0 == strcmp(&arg[0],"@"));
+
+	char* expected[3] = {"@", ":", "" };
+	for (int i = 0; i < 3; i++)
+	{
+	  memset(&arg[0], '\0', 16 * sizeof(char));
+	  method_getArgumentType(barMethod, i, &arg[0], 16);
+	  assert(0 == strcmp(&arg[0],expected[i]));
+	}
+
+
+	memset(&arg[0], '\0', 16 * sizeof(char));
+	method_getReturnType(setBarMethod, &arg[0], 16);
+	assert(0 == strcmp(&arg[0],"v"));
+
+        expected[2] = "@";
+
+	for (int i = 0; i < 3; i++)
+	{
+	  memset(&arg[0], '\0', 16 * sizeof(char));
+	  method_getArgumentType(setBarMethod, i, &arg[0], 16);
+	  assert(0 == strcmp(&arg[0],expected[i]));
+	}
+
+	char *arg_copied = method_copyReturnType(barMethod);
+	assert(0 == strcmp(arg_copied,"@"));
+	free(arg_copied);
+	arg_copied = NULL;
+
+	for (int i = 0; i < 2; i++) 
+	{
+	  arg_copied = method_copyArgumentType(barMethod, i);
+	  assert(0 == strcmp(arg_copied,expected[i]));
+	  free(arg_copied);
+	}
+
+	arg_copied = method_copyArgumentType(barMethod, 2);
+	assert(NULL == arg_copied);
+
+
+
+	arg_copied = method_copyReturnType(setBarMethod);
+	assert(0 == strcmp(arg_copied,"v"));
+	free(arg_copied);
+
+	for (int i = 0; i < 3; i++) 
+	{
+	  arg_copied = method_copyArgumentType(setBarMethod, i);
+	  assert(0 == strcmp(arg_copied,expected[i]));
+	  free(arg_copied);
+	}
+
+
+	return 0;
+}

--- a/encoding2.c
+++ b/encoding2.c
@@ -433,7 +433,7 @@ unsigned method_get_number_of_arguments(struct objc_method *method)
 char* method_copyArgumentType(Method method, unsigned int index)
 {
 	if (NULL == method) { return NULL; }
-	const char *types = findParameterStart(method->types, index);
+	const char *types = findParameterStart(method->types, index + 1);
 	if (NULL == types)
 	{
 		return NULL;

--- a/encoding2.c
+++ b/encoding2.c
@@ -59,7 +59,9 @@ static char* copyTypeEncoding(const char *types)
 
 static const char * findParameterStart(const char *types, unsigned int index)
 {
-	for (unsigned int i=0 ; i<index ; i++)
+	// the upper bound of the loop is inclusive because the return type
+	// is the first element in the method signature
+	for (unsigned int i=0 ; i <= index ; i++)
 	{
 		types = objc_skip_argspec(types);
 		if ('\0' == *types)
@@ -393,7 +395,7 @@ void method_getArgumentType(Method method,
                             size_t dst_len)
 {
 	if (NULL == method) { return; }
-	const char *types = findParameterStart(method->types, index + 1);
+	const char *types = findParameterStart(method->types, index);
 	if (NULL == types)
 	{
 		strncpy(dst, "", dst_len);
@@ -433,7 +435,7 @@ unsigned method_get_number_of_arguments(struct objc_method *method)
 char* method_copyArgumentType(Method method, unsigned int index)
 {
 	if (NULL == method) { return NULL; }
-	const char *types = findParameterStart(method->types, index + 1);
+	const char *types = findParameterStart(method->types, index);
 	if (NULL == types)
 	{
 		return NULL;

--- a/encoding2.c
+++ b/encoding2.c
@@ -393,7 +393,7 @@ void method_getArgumentType(Method method,
                             size_t dst_len)
 {
 	if (NULL == method) { return; }
-	const char *types = findParameterStart(method->types, index);
+	const char *types = findParameterStart(method->types, index + 1);
 	if (NULL == types)
 	{
 		strncpy(dst, "", dst_len);


### PR DESCRIPTION
A tiny fix: method_copyArgumentType() didn't account for the fact that the return type is the first element in the method signature.