### PR TITLE
Fix throwing nil exceptions.

### DIFF
--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TESTS
 	WeakReferences_arc.m
 	objc_msgSend.m
 	msgInterpose.m
+	NilException.m
 )
 
 # Function for adding a test.  This takes the name of the test and the list of

--- a/Test/NilException.m
+++ b/Test/NilException.m
@@ -1,5 +1,23 @@
 #include "Test.h"
 
+
+#ifdef __has_attribute
+#if __has_attribute(objc_root_class)
+__attribute__((objc_root_class))
+#endif
+#endif
+@interface NSObject
+{
+  Class isa;
+}
+@end
+
+@implementation NSObject
++ (id)new
+{
+	return class_createInstance(self, 0);
+}
+@end
 int main(void)
 {
 	BOOL caught_exception = NO;
@@ -7,9 +25,23 @@ int main(void)
 	{
 		@throw(nil);
 	}
+	@catch (NSObject* o)
+	{
+		assert(0);
+	}
 	@catch (id x)
 	{
 		assert(nil == x);
+		caught_exception = YES;
+	}
+	assert(caught_exception == YES);
+	caught_exception = NO;
+	@try
+	{
+		@throw(nil);
+	}
+	@catch (...)
+	{
 		caught_exception = YES;
 	}
 	assert(caught_exception == YES);

--- a/Test/NilException.m
+++ b/Test/NilException.m
@@ -1,0 +1,17 @@
+#include "Test.h"
+
+int main(void)
+{
+	BOOL caught_exception = NO;
+	@try
+	{
+		@throw(nil);
+	}
+	@catch (id x)
+	{
+		assert(nil == x);
+		caught_exception = YES;
+	}
+	assert(caught_exception == YES);
+	return 0;
+}

--- a/eh_personality.c
+++ b/eh_personality.c
@@ -358,7 +358,10 @@ static inline _Unwind_Reason_Code internal_objc_personality(int version,
 	else if (!foreignException)
 	{
 		ex = objc_exception_from_header(exceptionObject);
-		thrown_class = classForObject(ex->object);
+		if (ex->object != nil)
+	        {
+			thrown_class = classForObject(ex->object);
+		}
 	}
 	else if (_objc_class_for_boxing_foreign_exception)
 	{


### PR DESCRIPTION
The following is perfectly legal on Mac OS X:

```objc
@try
{
  @throw(nil);
}
@catch (id obj)
{
  printf("Caught: %p", obj);
}
```
It doesn't work presently because we were trying to dereference the object pointer to determine the class.