### PR TITLE
Fix a segfault on (s|g)etting ivars.

### DIFF
--- a/Test/ivar_arc.m
+++ b/Test/ivar_arc.m
@@ -20,14 +20,29 @@ int dealloc = 0;
 }
 @end
 
+@interface EmptySubFoo : Foo
+@end
+
+@implementation EmptySubFoo
+@end
+
+@interface NonEmptySubFoo : Foo
+{
+  __strong id ignored; 
+}
+@end
+
+@implementation NonEmptySubFoo
+@end
+
 void setIvar(id obj, const char * name, id val)
 {
 	object_setIvar(obj, class_getInstanceVariable(object_getClass(obj), name), val);
 }
 
-int main(void)
+void testIvarsOn(Foo* f)
 {
-	Foo *f = [Foo new];
+	dealloc = 0;
 	Dealloc *d = [Dealloc new];
 	__unsafe_unretained Dealloc *dead;
 	setIvar(f, "w", d);
@@ -48,5 +63,15 @@ int main(void)
 	setIvar(f, "s", nil);
 	assert(dealloc == 1);
 	assert(f->s == nil);
-	return 0;
+}
+
+int main (void)
+{
+	/* Test for ivars in the same class */
+        testIvarsOn([Foo new]);
+	/* Test for ivars in the superclass (receiver ivar list empty) */
+        testIvarsOn([EmptySubFoo new]);
+	/* Test for ivars in the superclass (receiver ivar list non-empty) */
+        testIvarsOn([NonEmptySubFoo new]);
+        return 0;
 }

--- a/ivar.c
+++ b/ivar.c
@@ -154,7 +154,8 @@ typedef enum {
 ownership ownershipForIvar(Class cls, Ivar ivar)
 {
 	struct objc_ivar_list *list = cls->ivars;
-	if ((ivar < list->ivar_list) || (ivar >= &list->ivar_list[list->count]))
+	if ((list == NULL) || (ivar < list->ivar_list)
+          || (ivar >= &list->ivar_list[list->count]))
 	{
 		// Try the superclass
 		if (cls->super_class)


### PR DESCRIPTION
When we were trying to get or set an ivar on a class that had
no ivars defined, we'd dereference a NULL ivar list while
determining the ownership qualifier.

I've fixed that, and extended the test case to cover this case (and the case where the receiver has a non-NULL ivar list)