### PR TITLE
Fix sarray2.h to build with gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,26 @@
 os:
-    - linux
-    - osx
+  - linux
+  - osx
 language: cpp
 compiler: clang
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gobjc
+before_script: >
+  if [ "$CC" = "gcc" ];
+  then
+    export ENABLE_TESTS=false
+  else
+    export ENABLE_TESTS=true
+  fi
 script:
-        - mkdir build
-        - cd build
-        - cmake -DCMAKE_BUILD_TYPE=Debug ..
-        - cmake --build .
-        - ctest
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_BUILD_TYPE=Debug -DTESTS=$ENABLE_TESTS ..
+  - cmake --build .
+  - ctest

--- a/sarray2.h
+++ b/sarray2.h
@@ -21,7 +21,7 @@
 #ifdef __clang__
 static const uint32_t data_size = 256;
 #else
-#define data_size 256
+#define data_size (uint32_t)256
 #endif
 /**
  * The mask used to access the elements in the data array in a sparse array

--- a/sarray2.h
+++ b/sarray2.h
@@ -18,12 +18,21 @@
  * The size of the data array.  The sparse array is a tree with this many
  * children at each node depth.
  */
+#ifdef __clang__
 static const uint32_t data_size = 256;
+#else
+#define data_size 256
+#endif
 /**
  * The mask used to access the elements in the data array in a sparse array
  * node.
  */
+#ifdef __clang__
 static const uint32_t data_mask = data_size - 1;
+#else
+#define data_mask (data_size - 1)
+#endif
+
 /**
  * Sparse arrays, used to implement dispatch tables.  Current implementation is
  * quite RAM-intensive and could be optimised.  Maps 32-bit integers to pointers.


### PR DESCRIPTION
Hi David,

gcc and clang disagree on to deal with const expressions in static initialisations (bug report [here](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53091)), so the sparse array code currently doesn't compile with gcc. Making data_size and data_mask #defines when not compiling with clang helps.
