### PR TITLE
Add objc-runtime.h to objc headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ set(libobjc_HDRS
 	objc/objc-api.h
 	objc/objc-arc.h
 	objc/objc-auto.h
+	objc/objc-runtime.h
 	objc/objc.h
 	objc/runtime-deprecated.h
 	objc/runtime.h

--- a/objc/objc-runtime.h
+++ b/objc/objc-runtime.h
@@ -1,0 +1,2 @@
+#include <objc/runtime.h>
+#include <objc/message.h>


### PR DESCRIPTION
Some applications still include the old objc-runtime.h header expecting
to obtain the declarations contained in objc/message.h and
objc/runtime.h nowadays. This commit adds this header to achieve
out-of-the-box compatibility with these applications.

(Context: this is one of the issues that arise when trying to build WebKit against GNUstep's libobjc2.)