### PR TITLE
blocks_runtime: create aliases for type encoding getters

### DIFF
--- a/objc/blocks_runtime.h
+++ b/objc/blocks_runtime.h
@@ -2,6 +2,10 @@
 #pragma clang system_header
 #endif
 
+#ifndef __has_feature
+#	define __has_feature(x) 0
+#endif
+
 /*
  * Blocks Runtime
  */
@@ -19,3 +23,14 @@ BLOCKS_EXPORT const char *block_getType_np(void *b) OBJC_NONPORTABLE;
 
 #define Block_copy(x) ((__typeof(x))_Block_copy((void *)(x)))
 #define Block_release(x) _Block_release((void *)(x))
+
+/*
+ * Aliases for block signature macros
+ */
+#if __has_feature(objc_arc)
+#define _Block_signature(x) block_getType_np((__bridge void *)(x))
+#define _Block_has_signature(x) (block_getType_np((__bridge void *)(x)) != NULL)
+#else
+#define _Block_signature(x) block_getType_np((void *)(x))
+#define _Block_has_signature(x) (block_getType_np((void *)(x)) != NULL)
+#endif


### PR DESCRIPTION
Add _Block_has_signature() and _Block_signature() alises for calls to
block_getType_np() for increased compatibility with other
implementations of libobjc2.

**Reasoning**: WebKit uses private libobjc APIs like `_Block_signature` to do what `block_getType_np` does, and requires them to be available.

Actually, adding these macros still wouldn't make that part of WebKit fully compatible with libobjc2, since WK actually expects `_Block_signature` to be an undeclared exported symbol in libobjc (it redeclares the function as an `extern` in its own code, which would fail compilation under the changes in this pull request). But reproducing these conditions in libobjc2 just wouldn't make any sense.

However, having this alias in libobjc2 still seems like it could serve to improve compatibility between libobjc2 and Apple's libobjc – although I don't know if the project has previously made a decision to ignore parity with private APIs. In this case, I'll understand if the pull request is rejected and will move these changes to my GNUstep-compatible fork of WebKit.