### PR TITLE
build: add compatibility symlink for block headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,12 @@
 cmake_minimum_required(VERSION 2.8)
 
-
 project(libobjc)
 enable_language(ASM)
+
+macro(install_symlink filepath sympath)
+	install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${filepath} ${sympath})")
+	install(CODE "message(\"-- Symlinking: ${sympath} -> ${filepath}\")")
+endmacro(install_symlink)
 
 set(CMAKE_C_FLAGS_DEBUG "-g -O0 -fno-inline ${CMAKE_C_FLAGS_DEBUG}")
 set(CMAKE_C_FLAGS_RELEASE "-O3 ${CMAKE_C_FLAGS_RELEASE}")
@@ -309,7 +313,8 @@ install(TARGETS ${INSTALL_TARGETS}
 install(FILES ${libobjc_HDRS}
 	DESTINATION "${HEADER_INSTALL_PATH}/${INCLUDE_DIRECTORY}")
 
-
+install_symlink(${HEADER_INSTALL_PATH}/${INCLUDE_DIRECTORY}/blocks_runtime.h ${HEADER_INSTALL_PATH}/Block.h)
+install_symlink(${HEADER_INSTALL_PATH}/${INCLUDE_DIRECTORY}/blocks_private.h ${HEADER_INSTALL_PATH}/Block_private.h)
 
 set(CPACK_GENERATOR TGZ CACHE STRING
 	"Installer types to generate.  Sensible options include TGZ, RPM and DEB")


### PR DESCRIPTION
A description of what this does can be found in the commit message. This is a follow-up to the discussion in #34.

The symlink installation will replace whatever's in the install prefix's `Block.h` and `Block_private.h` with a symlink to `blocks_runtime.h` and `blocks_private.h` respectively. (At least from what I could observe under CMake 3.8.0. I cannot assert that the same will happen in previous versions.)

Also, the cmake command I am using to generate symlinks only works on Unix-like platforms, and I do not know how one would make this Windows-compatible. Do you have any suggestions?