### PR TITLE
Add objc-class.h to objc headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ set(libobjc_HDRS
 	objc/objc-api.h
 	objc/objc-arc.h
 	objc/objc-auto.h
+	objc/objc-class.h
 	objc/objc-runtime.h
 	objc/objc.h
 	objc/runtime-deprecated.h

--- a/objc/objc-class.h
+++ b/objc/objc-class.h
@@ -1,0 +1,2 @@
+#include <objc/runtime.h>
+#include <objc/message.h>


### PR DESCRIPTION
This one is pretty much equal to that other pull request for objc-runtime.h, but with a different header that just came up. :)