### PR TITLE
1.8.1-FAR

### DIFF
--- a/ivar.c
+++ b/ivar.c
@@ -149,8 +149,13 @@ PRIVATE void objc_compute_ivar_offsets(Class class)
 void object_setIvar(id object, Ivar ivar, id value)
 {
 	char *addr = (char*)object;
-	addr += ivar_getOffset(ivar);
-	*(id*)addr = value;
+	unsigned offset;
+	
+	if (ivar && (offset = ivar_getOffset(ivar)))
+		{
+		addr += offset;
+		*(id*)addr = value;
+		}
 }
 
 Ivar object_setInstanceVariable(id obj, const char *name, void *value)


### PR DESCRIPTION
A more robust fix would perform bounds checking of the Ivar's offset (s/b within a min/max for the class).  The object_getIvar() function should also probably return nil if passed a NULL Ivar (or a nil object). 

This patch does not address the second item mentioned in Issue #39 which affects the Master branch.