### PR TITLE
clang x86_64-w64-mingw32 changes

### DIFF
--- a/asmconstants.h
+++ b/asmconstants.h
@@ -5,11 +5,11 @@
 #define DATA_OFFSET    8
 #define SLOT_OFFSET    32
 #elif (__SIZEOF_LONG__ == 4) && (__SIZEOF_POINTER__ == 8)  /* LLP64 */
-#define DTABLE_OFFSET  52   /* 5 pointers + 3 longs */
+#define DTABLE_OFFSET  56   /* 5 pointers + 3 longs + padding */
 #define SMALLOBJ_BITS  3
 #define SHIFT_OFFSET   0
 #define DATA_OFFSET    8
-#define SLOT_OFFSET    28   /* 3 pointers + 1 long */
+#define SLOT_OFFSET    32   /* 3 pointers + 1 long + padding */
 #else
 #define DTABLE_OFFSET  32
 #define SMALLOBJ_BITS  1

--- a/asmconstants.h
+++ b/asmconstants.h
@@ -4,6 +4,12 @@
 #define SHIFT_OFFSET   0
 #define DATA_OFFSET    8
 #define SLOT_OFFSET    32
+#elif (__SIZEOF_LONG__ == 4) && (__SIZEOF_POINTER__ == 8)  /* LLP64 */
+#define DTABLE_OFFSET  52   /* 5 pointers + 3 longs */
+#define SMALLOBJ_BITS  3
+#define SHIFT_OFFSET   0
+#define DATA_OFFSET    8
+#define SLOT_OFFSET    28   /* 3 pointers + 1 long */
 #else
 #define DTABLE_OFFSET  32
 #define SMALLOBJ_BITS  1

--- a/block_to_imp.c
+++ b/block_to_imp.c
@@ -35,6 +35,16 @@ void __clear_cache(void* start, void* end);
 
 #define PAGE_SIZE 4096
 
+/* MINGW32 does not include implementation of valloc() or a prototype for mprotect */
+#ifdef __MINGW32__
+int mprotect(void *addr, size_t len, int prot);
+
+inline void *valloc(size_t size)
+{
+    return _aligned_malloc(PAGE_SIZE, size);
+}
+#endif
+
 struct block_header
 {
 	void *block;

--- a/block_to_imp.c
+++ b/block_to_imp.c
@@ -35,8 +35,8 @@ void __clear_cache(void* start, void* end);
 
 #define PAGE_SIZE 4096
 
-/* MINGW32 does not include implementation of valloc() or a prototype for mprotect */
-#ifdef __MINGW32__
+/* MINGW64 does not include implementation of valloc() or a prototype for mprotect */
+#ifdef __MINGW64__
 int mprotect(void *addr, size_t len, int prot);
 
 inline void *valloc(size_t size)

--- a/common.S
+++ b/common.S
@@ -1,7 +1,14 @@
 /* use __USER_LABEL_PREFIX__ if it is available */
 #if defined(__USER_LABEL_PREFIX__)
-#define CDECL_PREFIX(x) x
-#define CDECL(symbol) CDECL_PREFIX(__USER_LABEL_PREFIX__) ## symbol
+    /* define symbol here for each possible non-empty prefix */
+#   define ULP_  1
+    /* define macro depending on result */
+#   define ULP_PASTE(x,y) X##y
+#   if ULP_PASTE(ULP, __USER_LABEL_PREFIX__) == 1
+#       define CDECL(symbol) _##symbol
+#   else
+#       define CDECL(symbol) symbol
+#   endif
 #elif defined(__WIN32__) || defined(__APPLE__)
 #define CDECL(symbol) _##symbol
 #else

--- a/common.S
+++ b/common.S
@@ -1,4 +1,8 @@
-#if defined(__WIN32__) || defined(__APPLE__)
+/* use __USER_LABEL_PREFIX__ if it is available */
+#if defined(__USER_LABEL_PREFIX__)
+#define CDECL_PREFIX(x) x
+#define CDECL(symbol) CDECL_PREFIX(__USER_LABEL_PREFIX__) ## symbol
+#elif defined(__WIN32__) || defined(__APPLE__)
 #define CDECL(symbol) _##symbol
 #else
 #define CDECL(symbol) symbol

--- a/objc/runtime.h
+++ b/objc/runtime.h
@@ -124,7 +124,7 @@ typedef struct objc_method *Method;
 #	ifdef STRICT_APPLE_COMPATIBILITY
 typedef signed char BOOL;
 #	else
-#		ifdef __vxwords
+#		if defined(__vxwords) || defined(__MINGW64__)
 typedef  int BOOL;
 #		else
 typedef unsigned char BOOL;

--- a/spinlock.h
+++ b/spinlock.h
@@ -1,6 +1,6 @@
-#ifdef __MINGW32__
+#if defined(__MINGW32__) && !defined(__MINGW64__)
 #include <windows.h>
-inline unsigned sleep(unsigned seconds)
+static unsigned sleep(unsigned seconds)
 {
 	Sleep(seconds*1000);
 	return 0;

--- a/spinlock.h
+++ b/spinlock.h
@@ -1,6 +1,6 @@
 #ifdef __MINGW32__
 #include <windows.h>
-static unsigned sleep(unsigned seconds)
+inline unsigned sleep(unsigned seconds)
 {
 	Sleep(seconds*1000);
 	return 0;

--- a/unwind-itanium.h
+++ b/unwind-itanium.h
@@ -33,6 +33,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 extern "C" {
 #endif
 
+/* definitions below do not handle LLP64, so use compiler definitions */
+#ifdef __MINGW32__
+#include <unwind.h>
+#else
+
 /* Minimal interface as per C++ ABI draft standard:
 
 	http://www.codesourcery.com/cxx-abi/abi-eh.html */
@@ -146,6 +151,8 @@ extern void *_Unwind_FindEnclosingFunction (void *);
     http://www.linuxbase.org/spec/refspecs/LSB_1.3.0/gLSB/gLSB/libgcc-s.html */
 
 #endif /* _GNU_SOURCE */
+    
+#endif /* __MINGW32__ */
 
 #define DECLARE_PERSONALITY_FUNCTION(name) \
 _Unwind_Reason_Code name(int version,\

--- a/unwind-itanium.h
+++ b/unwind-itanium.h
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 /* definitions below do not handle LLP64, so use compiler definitions */
-#ifdef __MINGW32__
+#ifdef __MINGW64__
 #include <unwind.h>
 #else
 
@@ -152,7 +152,7 @@ extern void *_Unwind_FindEnclosingFunction (void *);
 
 #endif /* _GNU_SOURCE */
     
-#endif /* __MINGW32__ */
+#endif /* __MINGW64__ */
 
 #define DECLARE_PERSONALITY_FUNCTION(name) \
 _Unwind_Reason_Code name(int version,\


### PR DESCRIPTION
clang target x86_64-w64-mingw32 uses LLP64 model so defined offsets for this model to asmconstants.h and altered unwind-itanium.h to directly include definitions from the compiler's unwind.h

Other changes add prototype for mprotect and implementation for valloc and change static keyword to inline to remove clang error.

These changes eliminate compile errors; there are still the following link errors:

```
[ 17%] Linking C shared library objc2.dll
CMakeFiles/objc.dir/properties.m.obj:(.rdata+0xa2): multiple definition of `.objc_sel_namecopy'
CMakeFiles/objc.dir/associate.m.obj:(.rdata+0x43): first defined here
CMakeFiles/objc.dir/Protocol2.m.obj:(.text+0x5d): undefined reference to `__imp___objc_exec_class'
CMakeFiles/objc.dir/arc.m.obj:(.text+0x1d8d): undefined reference to `__imp___objc_exec_class'
CMakeFiles/objc.dir/associate.m.obj:(.text+0xfad): undefined reference to `__imp___objc_exec_class'
CMakeFiles/objc.dir/properties.m.obj:(.text+0x1acd): undefined reference to `__imp___objc_exec_class'
```
