### PR TITLE
Use the old association policy to determine whether to release an object

### DIFF
--- a/associate.m
+++ b/associate.m
@@ -166,12 +166,17 @@ static void setReference(struct reference_list *list,
 		lock = lock_for_pointer(r);
 		lock_spinlock(lock);
 	}
-	r->policy = policy;
-	id old = r->object;
-	r->object = obj;
-	if (OBJC_ASSOCIATION_ASSIGN != r->policy)
+	@try
 	{
-		objc_release(old);
+		if (OBJC_ASSOCIATION_ASSIGN != r->policy)
+		{
+			objc_release(r->object);
+		}
+	}
+	@finally
+	{
+		r->policy = policy;
+		r->object = obj;
 	}
 	if (needLock)
 	{


### PR DESCRIPTION
This commit has been updated to address @davidchisnall's comments in https://github.com/Microsoft/libobjc2/commit/df7f9061670cce994730d1720150adc