### PR TITLE
fix objc_resolve_class_links to actually rescan the unresolved list

### DIFF
--- a/class_table.c
+++ b/class_table.c
@@ -258,10 +258,10 @@ PRIVATE BOOL objc_resolve_class(Class cls)
 PRIVATE void objc_resolve_class_links(void)
 {
 	LOCK_RUNTIME_FOR_SCOPE();
-	Class class = unresolved_class_list;
 	BOOL resolvedClass;
 	do
 	{
+		Class class = unresolved_class_list;
 		resolvedClass = NO;
 		while ((Nil != class))
 		{


### PR DESCRIPTION
It looks like this was the initial intent of 4ea82e1, but as implemented
it would still only scan the unresolved class list once. Since
unresolved_class_list represents the head and classes are pushed onto
the head, any classes added to the resolution list after resolution
started would be skipped.