### PR TITLE
win32: use native threading APIs instead of pthreads

### DIFF
--- a/eh_personality.c
+++ b/eh_personality.c
@@ -562,7 +562,7 @@ struct thread_data *get_thread_data(void)
 	}
 	return td;
 #else
-	return &td;
+	return &thread_data;
 #endif
 }
 
@@ -572,7 +572,7 @@ struct thread_data *get_thread_data_fast(void)
 	struct thread_data *td = pthread_getspecific(key);
 	return td;
 #else
-	return &td;
+	return &thread_data;
 #endif
 }
 

--- a/lock.h
+++ b/lock.h
@@ -6,15 +6,13 @@
 
 #ifndef __LIBOBJC_LOCK_H_INCLUDED__
 #define __LIBOBJC_LOCK_H_INCLUDED__
-#ifdef WIN32
-#define BOOL _WINBOOL
-#	include <windows.h>
-#undef BOOL
-typedef HANDLE mutex_t;
-#	define INIT_LOCK(x) x = CreateMutex(NULL, FALSE, NULL)
-#	define LOCK(x) WaitForSingleObject(*x, INFINITE)
-#	define UNLOCK(x) ReleaseMutex(*x)
-#	define DESTROY_LOCK(x) CloseHandle(*x)
+#ifdef _WIN32
+#	include "safewindows.h"
+typedef CRITICAL_SECTION mutex_t;
+#	define INIT_LOCK(x) InitializeCriticalSection(&(x))
+#	define LOCK(x) EnterCriticalSection(x)
+#	define UNLOCK(x) LeaveCriticalSection(x)
+#	define DESTROY_LOCK(x) DeleteCriticalSection(x)
 #else
 
 #	include <pthread.h>

--- a/safewindows.h
+++ b/safewindows.h
@@ -1,0 +1,20 @@
+#ifndef __LIBOBJC_SAFEWINDOWS_H_INCLUDED__
+#define __LIBOBJC_SAFEWINDOWS_H_INCLUDED__
+
+#pragma push_macro("BOOL")
+
+#ifdef BOOL
+#undef BOOL
+#endif
+#define BOOL _WINBOOL
+
+#include <Windows.h>
+
+// Windows.h defines interface -> struct
+#ifdef interface
+#undef interface
+#endif
+
+#pragma pop_macro("BOOL")
+
+#endif // __LIBOBJC_SAFEWINDOWS_H_INCLUDED__

--- a/spinlock.h
+++ b/spinlock.h
@@ -1,5 +1,5 @@
-#ifdef __MINGW32__
-#include <windows.h>
+#ifdef _WIN32
+#include "safewindows.h"
 static unsigned sleep(unsigned seconds)
 {
 	Sleep(seconds*1000);


### PR DESCRIPTION
* use fiber local storage if NO_PTHREADS is defined
* use critical sections instead of mutexes
