### PR TITLE
Add a test for e3b069c (association policy)

### DIFF
--- a/Test/AssociatedObject.m
+++ b/Test/AssociatedObject.m
@@ -19,8 +19,21 @@ int main(void)
 	@autoreleasepool {
 		Associated *object = [Associated new];
 		Test *holder = [[Test new] autorelease];
-		objc_setAssociatedObject(object, &objc_setAssociatedObjectKey, holder, OBJC_ASSOCIATION_RETAIN);
+		objc_setAssociatedObject(holder, &objc_setAssociatedObjectKey, object, OBJC_ASSOCIATION_RETAIN);
 		[object release];
-    }
+		assert(!deallocCalled);
+	}
+	// dealloc should be called when holder is released during pool drain
+	assert(deallocCalled);
+
+	deallocCalled = NO;
+
+	Associated *object = [Associated new];
+	Test *holder = [Test new];
+	objc_setAssociatedObject(holder, &objc_setAssociatedObjectKey, object, OBJC_ASSOCIATION_RETAIN);
+	[object release]; // commuted into associated object storage
+	objc_setAssociatedObject(holder, &objc_setAssociatedObjectKey, nil, OBJC_ASSOCIATION_ASSIGN);
+	[holder release];
+
 	assert(deallocCalled);
 }


### PR DESCRIPTION
This tests that the previously-associated object was properly released despite the new association policy not specifying ownership transfer.
Fails without e3b069c.

It looks like holder and object were swapped in the original test, and we were only testing that the autorelease pool did in fact release object (not that it was released through an association going away).