### PR TITLE
always look beyond the first page of associated objects

### DIFF
--- a/Test/AssociatedObject.m
+++ b/Test/AssociatedObject.m
@@ -1,4 +1,6 @@
 #include "Test.h"
+#include <stdio.h>
+#include <inttypes.h>
 
 static BOOL deallocCalled = NO;
 static const char* objc_setAssociatedObjectKey = "objc_setAssociatedObjectKey";
@@ -36,4 +38,24 @@ int main(void)
 	[holder release];
 
 	assert(deallocCalled);
+
+	object = [Associated new];
+	holder = [Test new];
+	for (uintptr_t i = 1; i <= 20; ++i)
+	{
+		objc_setAssociatedObject(holder, (void*)i, object, OBJC_ASSOCIATION_RETAIN);
+	}
+	int lost = 0;
+	for (uintptr_t i = 1; i <= 20; ++i)
+	{
+		if (object != objc_getAssociatedObject(holder, (void*)i))
+		{
+			fprintf(stderr, "lost object %" PRIuPTR "\n", i);
+			++lost;
+		}
+	}
+	[holder release];
+	[object release];
+	assert(0 == lost);
+	return 0;
 }

--- a/associate.m
+++ b/associate.m
@@ -75,14 +75,16 @@ static BOOL isAtomic(uintptr_t policy)
 
 static struct reference* findReference(struct reference_list *list, void *key)
 {
-	if (NULL == list) { return NULL; }
-
-	for (int i=0 ; i<REFERENCE_LIST_SIZE ; i++)
+	while (list)
 	{
-		if (list->list[i].key == key)
+		for (int i=0 ; i<REFERENCE_LIST_SIZE ; i++)
 		{
-			return &list->list[i];
+			if (list->list[i].key == key)
+			{
+				return &list->list[i];
+			}
 		}
+		list = list->next;
 	}
 	return NULL;
 }


### PR DESCRIPTION
Without this fix, we would lose associated objects silently after adding
the 11th. We would also allocate full pages for each object after the
11th because we couldn't find empty slots.