### PR TITLE
Fix some link-stage errors when compiling with Cygwin

### DIFF
--- a/common.S
+++ b/common.S
@@ -1,4 +1,4 @@
-#if (defined(_WIN32) && defined(__i386__)) || defined(_CYGWIN) || defined(__APPLE__)
+#if ((defined(_WIN32) || defined(__CYGWIN__)) && defined(__i386__)) || defined(__APPLE__)
 #define CDECL(symbol) _##symbol
 #else
 #define CDECL(symbol) symbol

--- a/common.S
+++ b/common.S
@@ -1,4 +1,4 @@
-#if (defined(_WIN32) && defined(__i386__)) || defined(__APPLE__)
+#if (defined(_WIN32) && defined(__i386__)) || defined(__CYGWIN32__) || defined(__APPLE__)
 #define CDECL(symbol) _##symbol
 #else
 #define CDECL(symbol) symbol

--- a/common.S
+++ b/common.S
@@ -1,4 +1,4 @@
-#if (defined(_WIN32) && defined(__i386__)) || defined(__CYGWIN32__) || defined(__APPLE__)
+#if (defined(_WIN32) && defined(__i386__)) || defined(_CYGWIN) || defined(__APPLE__)
 #define CDECL(symbol) _##symbol
 #else
 #define CDECL(symbol) symbol


### PR DESCRIPTION
Some errors still here such as
```
CMakeFiles/objc.dir/arc.m.o:(.text+0x2553): undefined reference to `_imp____objc_exec_class'
```

I found that those errors only occur on objc objects, I think it might be some bugs in clang or ld.