### PR TITLE
Clang++ provides its own exception types on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ set_source_files_properties(
 # C++ Runtime interaction
 #
 
+
 function(test_cxx CXX_RUNTIME_NAME IS_STDLIB)
 	set(CXX_RUNTIME_NAME "${CMAKE_SHARED_LIBRARY_PREFIX}${CXX_RUNTIME_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}")
 	find_library(CXX_RUNTIME_LIB NAMES ${CXX_RUNTIME_NAME})
@@ -382,13 +383,4 @@ if (CXA_ALLOCATE_EXCEPTION_NOEXCEPT_COMPILES)
 	add_definitions(-DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept)
 else ()
 	add_definitions(-DCXA_ALLOCATE_EXCEPTION_SPECIFIER=)
-endif ()
-
-CHECK_CXX_SOURCE_COMPILES("
-	#include <exception>
-	namespace std { class type_info { }; }
-	int main() { return 0; }" TYPE_INFO_REDEFINITION_COMPILES)
-
-if (NOT TYPE_INFO_REDEFINITION_COMPILES)
-	add_definitions(-DTYPE_INFO_IS_EXPOSED)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.1)
 project(libobjc)
 enable_language(ASM)
 
+INCLUDE (CheckCXXSourceCompiles)
+
 macro(install_symlink filepath sympath)
 	install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${filepath} ${sympath})")
 	install(CODE "message(\"-- Symlinking: ${sympath} -> ${filepath}\")")
@@ -367,9 +369,27 @@ if (TESTS)
 	add_subdirectory(Test)
 endif (TESTS)
 
-option(USE_PROVIDED_EXCEPTION_TYPES
-	"Whether to use the type_info structure and the __cxa__allocate_exception() prototype provided by libstdc++." FALSE)
+CHECK_CXX_SOURCE_COMPILES(
+	"
+	#include <stdlib.h>
+	extern \"C\" {
+	__attribute__((weak))
+	void *__cxa_allocate_exception(size_t thrown_size);
+	}
+	#include <exception>
+	int main() { return 0; }" CXA_ALLOCATE_EXCEPTION_CAN_THROW_COMPILES)
 
-if (USE_STD_EXCEPTION_TYPES)
-	add_definitions(-DUSE_STD_EXCEPTION_TYPES)
+if (NOT CXA_ALLOCATE_EXCEPTION_CAN_THROW_COMPILES)
+	add_definitions(-DCXA_ALLOCATE_EXCEPTION_IS_NOEXCEPT)
 endif ()
+
+CHECK_CXX_SOURCE_COMPILES(
+	"
+	#include <exception>
+	namespace std { class type_info { }; }
+	int main() { return 0; }" TYPE_INFO_REDEFINITION_COMPILES)
+
+if (NOT TYPE_INFO_REDEFINITION_COMPILES)
+	add_definitions(-DTYPE_INFO_IS_EXPOSED)
+endif ()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ set(INCLUDE_DIRECTORY "objc" CACHE STRING
 
 
 if (${CMAKE_C_COMPILER_ID} MATCHES Clang*)
-	set(CMAKE_OBJC_FLAGS "${CMAKE_OBJC_FLAGS} -Wno-deprecated-objc-isa-usage -Wno-objc-root-class -D_NATIVE_OBJC_EXCEPTIONS")
+	set(CMAKE_OBJC_FLAGS "${CMAKE_OBJC_FLAGS} -Wno-deprecated-objc-isa-usage -Wno-objc-root-class")
 	if (${CMAKE_C_COMPILER_VERSION} VERSION_GREATER 3.1)
 		set(CMAKE_OBJC_FLAGS "${CMAKE_OBJC_FLAGS} -fobjc-runtime=gnustep-1.7")
 	endif ()
@@ -161,10 +161,6 @@ set_source_files_properties(
 #
 # C++ Runtime interaction
 #
-
-if (${CMAKE_CXX_COMPILER_ID} MATCHES Clang*)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_NATIVE_OBJC_EXCEPTIONS")
-endif ()
 
 function(test_cxx CXX_RUNTIME_NAME IS_STDLIB)
 	set(CXX_RUNTIME_NAME "${CMAKE_SHARED_LIBRARY_PREFIX}${CXX_RUNTIME_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}")
@@ -370,3 +366,10 @@ if (TESTS)
 	enable_testing()
 	add_subdirectory(Test)
 endif (TESTS)
+
+option(USE_PROVIDED_EXCEPTION_TYPES
+	"Whether to use the type_info structure and the __cxa__allocate_exception() prototype provided by libstdc++." FALSE)
+
+if (USE_STD_EXCEPTION_TYPES)
+	add_definitions(-DUSE_STD_EXCEPTION_TYPES)
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,22 +369,22 @@ if (TESTS)
 	add_subdirectory(Test)
 endif (TESTS)
 
-CHECK_CXX_SOURCE_COMPILES(
-	"
+CHECK_CXX_SOURCE_COMPILES("
 	#include <stdlib.h>
 	extern \"C\" {
 	__attribute__((weak))
-	void *__cxa_allocate_exception(size_t thrown_size);
+	void *__cxa_allocate_exception(size_t thrown_size) noexcept;
 	}
 	#include <exception>
-	int main() { return 0; }" CXA_ALLOCATE_EXCEPTION_CAN_THROW_COMPILES)
+	int main() { return 0; }" CXA_ALLOCATE_EXCEPTION_NOEXCEPT_COMPILES)
 
-if (NOT CXA_ALLOCATE_EXCEPTION_CAN_THROW_COMPILES)
-	add_definitions(-DCXA_ALLOCATE_EXCEPTION_IS_NOEXCEPT)
+if (CXA_ALLOCATE_EXCEPTION_NOEXCEPT_COMPILES)
+	add_definitions(-DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept)
+else ()
+	add_definitions(-DCXA_ALLOCATE_EXCEPTION_SPECIFIER=)
 endif ()
 
-CHECK_CXX_SOURCE_COMPILES(
-	"
+CHECK_CXX_SOURCE_COMPILES("
 	#include <exception>
 	namespace std { class type_info { }; }
 	int main() { return 0; }" TYPE_INFO_REDEFINITION_COMPILES)
@@ -392,4 +392,3 @@ CHECK_CXX_SOURCE_COMPILES(
 if (NOT TYPE_INFO_REDEFINITION_COMPILES)
 	add_definitions(-DTYPE_INFO_IS_EXPOSED)
 endif ()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ set(INCLUDE_DIRECTORY "objc" CACHE STRING
 
 
 if (${CMAKE_C_COMPILER_ID} MATCHES Clang*)
-	set(CMAKE_OBJC_FLAGS "${CMAKE_OBJC_FLAGS} -Wno-deprecated-objc-isa-usage -Wno-objc-root-class")
+	set(CMAKE_OBJC_FLAGS "${CMAKE_OBJC_FLAGS} -Wno-deprecated-objc-isa-usage -Wno-objc-root-class -D_NATIVE_OBJC_EXCEPTIONS")
 	if (${CMAKE_C_COMPILER_VERSION} VERSION_GREATER 3.1)
 		set(CMAKE_OBJC_FLAGS "${CMAKE_OBJC_FLAGS} -fobjc-runtime=gnustep-1.7")
 	endif ()
@@ -162,6 +162,9 @@ set_source_files_properties(
 # C++ Runtime interaction
 #
 
+if (${CMAKE_CXX_COMPILER_ID} MATCHES Clang*)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_NATIVE_OBJC_EXCEPTIONS")
+endif ()
 
 function(test_cxx CXX_RUNTIME_NAME IS_STDLIB)
 	set(CXX_RUNTIME_NAME "${CMAKE_SHARED_LIBRARY_PREFIX}${CXX_RUNTIME_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}")
@@ -367,4 +370,3 @@ if (TESTS)
 	enable_testing()
 	add_subdirectory(Test)
 endif (TESTS)
-

--- a/objcxx_eh.cc
+++ b/objcxx_eh.cc
@@ -15,7 +15,6 @@ namespace __cxxabiv1
 
 using __cxxabiv1::__class_type_info;
 
-#ifndef TYPE_INFO_IS_EXPOSED
 namespace std
 {
 	/**
@@ -49,7 +48,6 @@ namespace std
 				                void **thrown_object) const;
 	};
 }
-#endif
 
 using namespace std;
 

--- a/objcxx_eh.cc
+++ b/objcxx_eh.cc
@@ -15,6 +15,7 @@ namespace __cxxabiv1
 
 using __cxxabiv1::__class_type_info;
 
+#ifndef _NATIVE_OBJC_EXCEPTIONS
 namespace std
 {
 	/**
@@ -48,6 +49,7 @@ namespace std
 				                void **thrown_object) const;
 	};
 }
+#endif
 
 using namespace std;
 

--- a/objcxx_eh.cc
+++ b/objcxx_eh.cc
@@ -15,7 +15,7 @@ namespace __cxxabiv1
 
 using __cxxabiv1::__class_type_info;
 
-#ifndef USE_STD_EXCEPTION_TYPES
+#ifndef TYPE_INFO_IS_EXPOSED
 namespace std
 {
 	/**

--- a/objcxx_eh.cc
+++ b/objcxx_eh.cc
@@ -15,7 +15,7 @@ namespace __cxxabiv1
 
 using __cxxabiv1::__class_type_info;
 
-#ifndef _NATIVE_OBJC_EXCEPTIONS
+#ifndef USE_STD_EXCEPTION_TYPES
 namespace std
 {
 	/**

--- a/objcxx_eh.h
+++ b/objcxx_eh.h
@@ -6,8 +6,8 @@ extern "C" {
  * is provided externally.
  */
 /*
- * Note: Recent versions of libstdc++ already provide a prototype for
- * __cxa__allocate_exception(). Since the standard version is defined with
+ * Note: Recent versions of libsupc++ already provide a prototype for
+ * __cxa__allocate_exception(). Since the libsupc++ version is defined with
  * _GLIBCXX_NOTHROW, clang gives a type mismatch error.
  */
 #ifndef __cplusplus

--- a/objcxx_eh.h
+++ b/objcxx_eh.h
@@ -10,10 +10,12 @@ extern "C" {
  * __cxa__allocate_exception(). Since the standard version is defined with
  * _GLIBCXX_NOTHROW, clang gives a type mismatch error.
  */
-#if !__cplusplus || !USE_STD_EXCEPTION_TYPES
 __attribute__((weak))
-void *__cxa_allocate_exception(size_t thrown_size);
+void *__cxa_allocate_exception(size_t thrown_size)
+#if defined __cplusplus && defined CXA_ALLOCATE_EXCEPTION_IS_NOEXCEPT
+  noexcept
 #endif
+;
 
 /**
  * Initialises an exception object returned by __cxa_allocate_exception() for

--- a/objcxx_eh.h
+++ b/objcxx_eh.h
@@ -5,8 +5,10 @@ extern "C" {
  * Allocates a C++ exception.  This function is part of the Itanium C++ ABI and
  * is provided externally.
  */
+#ifndef _NATIVE_OBJC_EXCEPTIONS
 __attribute__((weak))
 void *__cxa_allocate_exception(size_t thrown_size);
+#endif
 /**
  * Initialises an exception object returned by __cxa_allocate_exception() for
  * storing an Objective-C object.  The return value is the location of the

--- a/objcxx_eh.h
+++ b/objcxx_eh.h
@@ -5,10 +5,14 @@ extern "C" {
  * Allocates a C++ exception.  This function is part of the Itanium C++ ABI and
  * is provided externally.
  */
-#ifndef _NATIVE_OBJC_EXCEPTIONS
+/*
+ * Note: Recent version of libstdc++
+ */
+#if !__cplusplus || !USE_STD_EXCEPTION_TYPES
 __attribute__((weak))
 void *__cxa_allocate_exception(size_t thrown_size);
 #endif
+
 /**
  * Initialises an exception object returned by __cxa_allocate_exception() for
  * storing an Objective-C object.  The return value is the location of the

--- a/objcxx_eh.h
+++ b/objcxx_eh.h
@@ -10,12 +10,12 @@ extern "C" {
  * __cxa__allocate_exception(). Since the standard version is defined with
  * _GLIBCXX_NOTHROW, clang gives a type mismatch error.
  */
-__attribute__((weak))
-void *__cxa_allocate_exception(size_t thrown_size)
-#if defined __cplusplus && defined CXA_ALLOCATE_EXCEPTION_IS_NOEXCEPT
-  noexcept
+#ifndef __cplusplus
+#undef CXA_ALLOCATE_EXCEPTION_SPECIFIER
+#define CXA_ALLOCATE_EXCEPTION_SPECIFIER
 #endif
-;
+__attribute__((weak))
+void *__cxa_allocate_exception(size_t thrown_size) CXA_ALLOCATE_EXCEPTION_SPECIFIER;
 
 /**
  * Initialises an exception object returned by __cxa_allocate_exception() for

--- a/objcxx_eh.h
+++ b/objcxx_eh.h
@@ -6,7 +6,9 @@ extern "C" {
  * is provided externally.
  */
 /*
- * Note: Recent version of libstdc++
+ * Note: Recent versions of libstdc++ already provide a prototype for
+ * __cxa__allocate_exception(). Since the standard version is defined with
+ * _GLIBCXX_NOTHROW, clang gives a type mismatch error.
  */
 #if !__cplusplus || !USE_STD_EXCEPTION_TYPES
 __attribute__((weak))


### PR DESCRIPTION
Without disabling the existing definitions, clang will refuse to build libobjc2 on Ubuntu Linux 18.04. With this patch, the library compiles without problems.