### PR TITLE
Let go of the runtime lock properly in class_setSuperclass

### DIFF
--- a/runtime.c
+++ b/runtime.c
@@ -526,7 +526,10 @@ Class class_setSuperclass(Class cls, Class newSuper)
 
 	LOCK_RUNTIME();
 
-	if (cls->super_class == newSuper) { return newSuper; }
+	if (cls->super_class == newSuper) {
+		UNLOCK_RUNTIME();
+		return newSuper;
+	}
 
 	safe_remove_from_subclass_list(cls);
 	objc_resolve_class(newSuper);


### PR DESCRIPTION
This will almost certainly cause a deadlock if you use `class_setSuperclass` incorrectly, which WinObjC apparently does!