### PR TITLE
Actually emit storage for the objc_weak_load hook

### DIFF
--- a/arc.m
+++ b/arc.m
@@ -12,6 +12,8 @@
 #import "objc/objc-arc.h"
 #import "objc/blocks_runtime.h"
 
+id (*_objc_weak_load)(id object);
+
 #if defined(_WIN32)
 // We're using the Fiber-Local Storage APIs on Windows
 // because the TLS APIs won't pass app certification.


### PR DESCRIPTION
Without this, in Release builds on Windows, I experienced `symbol not found` errors when linking.