### PR TITLE
Use simple implementations for some weak ref table funnctions

### DIFF
--- a/arc.m
+++ b/arc.m
@@ -870,42 +870,14 @@ id objc_loadWeak(id* object)
 
 void objc_copyWeak(id *dest, id *src)
 {
-	// Don't retain or release.  While the weak ref lock is held, we know that
-	// the object can't be deallocated, so we just move the value and update
-	// the weak reference table entry to indicate the new address.
 	LOCK_FOR_SCOPE(&weakRefLock);
-	id obj;
-	WeakRef *srcRef;
-	WeakRef *dstRef;
-	loadWeakPointer(dest, &obj, &dstRef);
-	loadWeakPointer(src, &obj, &srcRef);
-	*dest = *src;
-	if (srcRef)
-	{
-		srcRef->weak_count++;
-	}
-	if (dstRef)
-	{
-		weakRefRelease(dstRef);
-	}
+	objc_release(objc_initWeak(dest, objc_loadWeakRetained(src)));
 }
 
 void objc_moveWeak(id *dest, id *src)
 {
-	// Don't retain or release.  While the weak ref lock is held, we know that
-	// the object can't be deallocated, so we just move the value and update
-	// the weak reference table entry to indicate the new address.
 	LOCK_FOR_SCOPE(&weakRefLock);
-	id obj;
-	WeakRef *oldRef;
-	// If the destination is a weak ref, free it.
-	loadWeakPointer(dest, &obj, &oldRef);
-	*dest = *src;
-	*src = nil;
-	if (oldRef != NULL)
-	{
-		weakRefRelease(oldRef);
-	}
+	objc_copyWeak(dest, src);
 }
 
 void objc_destroyWeak(id* obj)

--- a/objc_msgSend.arm.S
+++ b/objc_msgSend.arm.S
@@ -52,11 +52,9 @@
 	tst    \receiver, SMALLOBJ_MASK        // Sets Z if this is not a small int
 
 
-	ldr    r4, 6f
-42:
-	add    r4, pc
-	ldr    r4, [r4]
-	it     eq
+	itte   ne
+	ldrne  r4, LSmallIntClass              // Small Int class -> r4 if this is a small int
+	ldrne  r4, [r4]
 	ldreq  r4, [\receiver]                 // Load class to r4 if not a small int
 
 	ldr    r4, [r4, #DTABLE_OFFSET]        // Dtable -> r4
@@ -125,9 +123,6 @@
 #endif
 	bx     lr
 .fnend
-6:
-	.p2align 2
-	.long   SmallObjectClasses(GOT_PREL)-((42b+4)-6b)
 .endm
 
 .globl CDECL(objc_msgSend_fpret)
@@ -142,3 +137,6 @@ TYPE_DIRECTIVE(CDECL(objc_msgSend_stret), %function)
 CDECL(objc_msgSend_stret):
 	MSGSEND r1, r2
 
+LSmallIntClass:
+	.long   SmallObjectClasses
+	.align  2

--- a/objc_msgSend.arm.S
+++ b/objc_msgSend.arm.S
@@ -52,9 +52,11 @@
 	tst    \receiver, SMALLOBJ_MASK        // Sets Z if this is not a small int
 
 
-	itte   ne
-	ldrne  r4, LSmallIntClass              // Small Int class -> r4 if this is a small int
-	ldrne  r4, [r4]
+	ldr    r4, 6f
+42:
+	add    r4, pc
+	ldr    r4, [r4]
+	it     eq
 	ldreq  r4, [\receiver]                 // Load class to r4 if not a small int
 
 	ldr    r4, [r4, #DTABLE_OFFSET]        // Dtable -> r4
@@ -123,6 +125,9 @@
 #endif
 	bx     lr
 .fnend
+6:
+	.p2align 2
+	.long   SmallObjectClasses(GOT_PREL)-((42b+4)-6b)
 .endm
 
 .globl CDECL(objc_msgSend_fpret)
@@ -137,6 +142,3 @@ TYPE_DIRECTIVE(CDECL(objc_msgSend_stret), %function)
 CDECL(objc_msgSend_stret):
 	MSGSEND r1, r2
 
-LSmallIntClass:
-	.long   SmallObjectClasses
-	.align  2


### PR DESCRIPTION
So I can't explain this one well...  However on the 1.9 branch, on our android devices we had a bunch of memory corruption issues in the arc weak reference table.  I managed to track a few of them down by compiling and running our software under Addresses Sanitizer on armv7-a arch devices.    

There *seemed* to be a hash table bug, and perhaps something related to these functions.  I swapped out the the implementations with what's suggested in the arc spec and stability improved.  I'm not sure what the performance impact was however.
