### PR TITLE
Use `id` as type for block runtime functions.

### DIFF
--- a/block_to_imp.c
+++ b/block_to_imp.c
@@ -181,7 +181,7 @@ static struct trampoline_set *alloc_trampolines(char *start, char *end)
 static struct trampoline_set *sret_trampolines;
 static struct trampoline_set *trampolines;
 
-IMP imp_implementationWithBlock(void *block)
+IMP imp_implementationWithBlock(id block)
 {
 	struct Block_layout *b = block;
 	void *start;
@@ -250,7 +250,7 @@ static int indexForIMP(IMP anIMP, struct trampoline_set **setptr)
 	return -1;
 }
 
-void *imp_getBlock(IMP anImp)
+id imp_getBlock(IMP anImp)
 {
 	LOCK_FOR_SCOPE(&trampoline_lock);
 	struct trampoline_set *set = trampolines;
@@ -291,7 +291,7 @@ BOOL imp_removeBlock(IMP anImp)
 
 PRIVATE size_t lengthOfTypeEncoding(const char *types);
 
-char *block_copyIMPTypeEncoding_np(void*block)
+char *block_copyIMPTypeEncoding_np(id block)
 {
 	char *buffer = strdup(block_getType_np(block));
 	if (NULL == buffer) { return NULL; }

--- a/objc/runtime.h
+++ b/objc/runtime.h
@@ -1077,7 +1077,7 @@ void objc_removeAssociatedObjects(id object);
  * arguments as the method.
  */
 OBJC_PUBLIC
-IMP imp_implementationWithBlock(void *block);
+IMP imp_implementationWithBlock(id block);
 /**
  * Returns the type encoding of an IMP that would be returned by passing the
  * block to imp_implementationWithBlock().  Returns NULL if this is not a valid
@@ -1085,14 +1085,14 @@ IMP imp_implementationWithBlock(void *block);
  * argument).  The caller is responsible for freeing the returned value.
  */
 OBJC_PUBLIC
-char *block_copyIMPTypeEncoding_np(void*block);
+char *block_copyIMPTypeEncoding_np(id block);
 /**
  * Returns the block that was used in an IMP created by
  * imp_implementationWithBlock().  The result of calling this function with any
  * other IMP is undefined.
  */
 OBJC_PUBLIC
-void *imp_getBlock(IMP anImp);
+id imp_getBlock(IMP anImp);
 /**
  * Removes a block that was converted to an IMP with
  * imp_implementationWithBlock().  The result of calling this function with any


### PR DESCRIPTION
Fixes #103 on behalf of @rupertdaniel.