### PR TITLE
Use const pointers for associated object keys.

### DIFF
--- a/Test/AssociatedObject.m
+++ b/Test/AssociatedObject.m
@@ -48,7 +48,7 @@ int main(void)
 	int lost = 0;
 	for (uintptr_t i = 1; i <= 20; ++i)
 	{
-		if (object != objc_getAssociatedObject(holder, (void*)i))
+		if (object != objc_getAssociatedObject(holder, (const void*)i))
 		{
 			fprintf(stderr, "lost object %" PRIuPTR "\n", i);
 			++lost;

--- a/associate.m
+++ b/associate.m
@@ -22,7 +22,7 @@ struct reference
 	 * The key used for identifying this object.  Opaque pointer, should be set
 	 * to 0 when this slot is unused.
 	 */
-	void *key;
+	const void *key;
 	/**
 	 * The associated object.  Note, if the policy is assign then this may be
 	 * some other type of pointer...
@@ -73,7 +73,7 @@ static BOOL isAtomic(uintptr_t policy)
 	return (policy & OBJC_ASSOCIATION_ATOMIC) == OBJC_ASSOCIATION_ATOMIC;
 }
 
-static struct reference* findReference(struct reference_list *list, void *key)
+static struct reference* findReference(struct reference_list *list, const void *key)
 {
 	while (list)
 	{
@@ -121,7 +121,7 @@ static void freeReferenceList(struct reference_list *l)
 }
 
 static void setReference(struct reference_list *list,
-                         void *key,
+                         const void *key,
                          void *obj,
                          uintptr_t policy)
 {
@@ -324,7 +324,7 @@ static struct reference_list* referenceListForObject(id object, BOOL create)
 }
 
 void objc_setAssociatedObject(id object,
-                              void *key,
+                              const void *key,
                               id value,
                               objc_AssociationPolicy policy)
 {
@@ -333,7 +333,7 @@ void objc_setAssociatedObject(id object,
 	setReference(list, key, value, policy);
 }
 
-id objc_getAssociatedObject(id object, void *key)
+id objc_getAssociatedObject(id object, const void *key)
 {
 	if (isSmallObject(object)) { return nil; }
 	struct reference_list *list = referenceListForObject(object, NO);

--- a/objc/runtime.h
+++ b/objc/runtime.h
@@ -1054,7 +1054,7 @@ typedef uintptr_t objc_AssociationPolicy;
  * with the same arguments, or nil if none exists.
  */
 OBJC_PUBLIC
-id objc_getAssociatedObject(id object, void *key);
+id objc_getAssociatedObject(id object, const void *key);
 /**
  * Associates an object with another.  This provides a mechanism for storing
  * extra state with an object, beyond its declared instance variables.  The
@@ -1064,7 +1064,7 @@ id objc_getAssociatedObject(id object, void *key);
  * if an association policy of copy or retain is passed as the final argument.
  */
 OBJC_PUBLIC
-void objc_setAssociatedObject(id object, void *key, id value, objc_AssociationPolicy policy);
+void objc_setAssociatedObject(id object, const void *key, id value, objc_AssociationPolicy policy);
 /**
  * Removes all associations from an object.  
  */


### PR DESCRIPTION
Matches Apple platform implementations.