### PR TITLE
Rework ARC code as C++.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,6 +13,8 @@ task:
       git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
       git reset --hard $CIRRUS_CHANGE_IN_REPO
     fi
+    git submodule sync
+    git submodule update
 
   script: |
       mkdir Build

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,18 @@ freebsd_instance:
   image: freebsd-12-0-release-amd64
 
 task:
-  install_script: pkg install -y cmake ninja llvm80
+  install_script: pkg install -y cmake ninja llvm80 git
+
+  clone_script: |
+    if [ -z "$CIRRUS_PR" ]; then
+      git clone --recursive --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+      git reset --hard $CIRRUS_CHANGE_IN_REPO
+    else
+      git clone --recursive https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+      git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+      git reset --hard $CIRRUS_CHANGE_IN_REPO
+    fi
+
   script: |
       mkdir Build
       cd Build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/robin-map"]
+	path = third_party/robin-map
+	url = https://github.com/Tessil/robin-map

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,12 @@ add_definitions( -DGNUSTEP -D__OBJC_RUNTIME_INTERNAL__=1)
 set(libobjc_ASM_SRCS 
 	block_trampolines.S
 	objc_msgSend.S)
+set(libobjc_OBJCXX_SRCS 
+	arc.mm
+	)
 set(libobjc_OBJC_SRCS 
 	NSBlocks.m
 	Protocol2.m
-	arc.m
 	associate.m
 	blocks_runtime.m
 	properties.m)
@@ -193,6 +195,12 @@ set_source_files_properties(
 	COMPILE_FLAGS "${CMAKE_OBJC_FLAGS} -Xclang -x -Xclang objective-c"
 )
 
+set_source_files_properties(
+	${libobjc_OBJCXX_SRCS}
+	COMPILE_FLAGS "${CMAKE_OBJC_FLAGS} -Xclang -x -Xclang objective-c++"
+)
+
+
 #
 # C++ Runtime interaction
 #
@@ -252,7 +260,7 @@ if (MSVC)
 endif()
 
 
-add_library(objc SHARED ${libobjc_C_SRCS} ${libobjc_ASM_SRCS} ${libobjc_OBJC_SRCS} ${libobjc_ASM_OBJS})
+add_library(objc SHARED ${libobjc_C_SRCS} ${libobjc_ASM_SRCS} ${libobjc_OBJC_SRCS} ${libobjc_OBJCXX_SRCS} ${libobjc_ASM_OBJS})
 
 if (ENABLE_OBJCXX)
 	if (WIN32)

--- a/arc.mm
+++ b/arc.mm
@@ -56,9 +56,12 @@ static inline arc_tls_key_t arc_tls_key_create(arc_cleanup_function_t cleanupFun
 arc_tls_key_t ARCThreadKey;
 #endif
 
-extern struct objc_class _NSConcreteMallocBlock;
-extern struct objc_class _NSConcreteStackBlock;
-extern struct objc_class _NSConcreteGlobalBlock;
+extern "C"
+{
+	extern struct objc_class _NSConcreteMallocBlock;
+	extern struct objc_class _NSConcreteStackBlock;
+	extern struct objc_class _NSConcreteGlobalBlock;
+}
 
 @interface NSAutoreleasePool
 + (Class)class;
@@ -639,10 +642,23 @@ struct malloc_allocator
 	{
 		return static_cast<T*>(malloc(sizeof(T) * n));
 	}
+
 	void deallocate(T* p, std::size_t)
 	{
 		free(p);
 	}
+
+	template<typename X>
+	malloc_allocator &operator=(const malloc_allocator<X>&) const
+	{
+		return *this;
+	}
+
+	bool operator==(const malloc_allocator &) const
+	{
+		return true;
+	}
+
 	template<typename X>
 	operator malloc_allocator<X>() const
 	{

--- a/arc.mm
+++ b/arc.mm
@@ -1,3 +1,4 @@
+#define _LIBCPP_NO_EXCEPTIONS 1
 #define TSL_NO_EXCEPTIONS 1
 #include <stdio.h>
 #include <stdlib.h>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,8 @@ jobs:
         Release:
           BuildType: Release
     steps:
+    - checkout: self
+      submodules: true
     - script: |
         sudo add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
         sudo apt-get update
@@ -55,6 +57,8 @@ jobs:
           Arch: x64
           Flags: -m64
     steps:
+    - checkout: self
+      submodules: true
     - script: |
         choco.exe install ninja
         choco.exe install llvm

--- a/blocks_runtime.m
+++ b/blocks_runtime.m
@@ -62,7 +62,7 @@ OBJC_PUBLIC const char * _Block_signature(void *b)
 }
 OBJC_PUBLIC const char *block_getType_np(const void *b)
 {
-	return _Block_signature(b);
+	return _Block_signature((void*)b);
 }
 
 static int increment24(int *ref)

--- a/class.h
+++ b/class.h
@@ -1,6 +1,7 @@
 #ifndef __OBJC_CLASS_H_INCLUDED
 #define __OBJC_CLASS_H_INCLUDED
 #include "visibility.h"
+#include "objc/runtime.h"
 #include <stdint.h>
 
 /**
@@ -36,7 +37,6 @@ static inline BOOL objc_bitfield_test(uintptr_t bitfield, uint64_t field)
 	return (bf->values[byte] & bit) == bit;
 }
 
-
 // begin: objc_class
 struct objc_class
 {
@@ -45,13 +45,13 @@ struct objc_class
 	 * methods use when a message is sent to the class, rather than an
 	 * instance.
 	 */
-	struct objc_class         *isa;
+	Class                      isa;
 	/**
 	 * Pointer to the superclass.  The compiler will set this to the name of
 	 * the superclass, the runtime will initialize it to point to the real
 	 * class.
 	 */
-	struct objc_class         *super_class;
+	Class                      super_class;
 	/**
 	 * The name of this class.  Set to the same value for both the class and
 	 * its associated metaclass.
@@ -96,7 +96,7 @@ struct objc_class
 	 * A pointer to the first subclass for this class.  Filled in by the
 	 * runtime.
 	 */
-	struct objc_class         *subclass_list;
+	Class                      subclass_list;
 	/**
 	 * Pointer to the .cxx_construct method if one exists.  This method needs
 	 * to be called outside of the normal dispatch mechanism.
@@ -113,7 +113,7 @@ struct objc_class
 	 * then subsequently following the sibling_class pointers in the
 	 * subclasses.
 	 */
-	struct objc_class         *sibling_class;
+	Class                      sibling_class;
 
 	/**
 	 * Metadata describing the protocols adopted by this class.  Not used by
@@ -143,13 +143,13 @@ struct objc_class_gsv1
 	 * methods use when a message is sent to the class, rather than an
 	 * instance.
 	 */
-	struct objc_class         *isa;
+	Class                      isa;
 	/**
 	 * Pointer to the superclass.  The compiler will set this to the name of
 	 * the superclass, the runtime will initialize it to point to the real
 	 * class.
 	 */
-	struct objc_class         *super_class;
+	Class                      super_class;
 	/**
 	 * The name of this class.  Set to the same value for both the class and
 	 * its associated metaclass.
@@ -194,14 +194,14 @@ struct objc_class_gsv1
 	 * A pointer to the first subclass for this class.  Filled in by the
 	 * runtime.
 	 */
-	struct objc_class         *subclass_list;
+	Class                      subclass_list;
 	/**
 	 * A pointer to the next sibling class to this.  You may find all
 	 * subclasses of a given class by following the subclass_list pointer and
 	 * then subsequently following the sibling_class pointers in the
 	 * subclasses.
 	 */
-	struct objc_class         *sibling_class;
+	Class                      sibling_class;
 
 	/**
 	 * Metadata describing the protocols adopted by this class.  Not used by
@@ -277,17 +277,17 @@ struct objc_class_gsv1
  */
 struct objc_class_gcc
 {
-	struct objc_class         *isa;
-	struct objc_class         *super_class;
+	Class                      isa;
+	Class                      super_class;
 	const char                *name;
 	long                       version;
 	unsigned long              info;
 	long                       instance_size;
-	struct objc_ivar_list_gcc     *ivars;
+	struct objc_ivar_list_gcc *ivars;
 	struct objc_method_list   *methods;
 	void                      *dtable;
-	struct objc_class         *subclass_list;
-	struct objc_class         *sibling_class;
+	Class                      subclass_list;
+	Class                      sibling_class;
 	struct objc_protocol_list *protocols;
 	void                      *gc_object_type;
 };
@@ -357,7 +357,7 @@ enum objc_class_flags
 /**
  * Sets the specific class flag.  Note: This is not atomic.
  */
-static inline void objc_set_class_flag(struct objc_class *aClass,
+static inline void objc_set_class_flag(Class aClass,
                                        enum objc_class_flags flag)
 {
 	aClass->info |= (unsigned long)flag;
@@ -365,7 +365,7 @@ static inline void objc_set_class_flag(struct objc_class *aClass,
 /**
  * Unsets the specific class flag.  Note: This is not atomic.
  */
-static inline void objc_clear_class_flag(struct objc_class *aClass,
+static inline void objc_clear_class_flag(Class aClass,
                                          enum objc_class_flags flag)
 {
 	aClass->info &= ~(unsigned long)flag;
@@ -373,7 +373,7 @@ static inline void objc_clear_class_flag(struct objc_class *aClass,
 /**
  * Checks whether a specific class flag is set.
  */
-static inline BOOL objc_test_class_flag(struct objc_class *aClass,
+static inline BOOL objc_test_class_flag(Class aClass,
                                         enum objc_class_flags flag)
 {
 	return (aClass->info & (unsigned long)flag) == (unsigned long)flag;
@@ -383,7 +383,7 @@ static inline BOOL objc_test_class_flag(struct objc_class *aClass,
 /**
  * Adds a class to the class table.
  */
-void class_table_insert(Class class);
+void class_table_insert(Class cls);
 
 /**
  * Removes a class from the class table.  Must be called with the runtime lock

--- a/class.h
+++ b/class.h
@@ -4,6 +4,11 @@
 #include "objc/runtime.h"
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 /**
  * Overflow bitfield.  Used for bitfields that are more than 63 bits.
  */
@@ -443,4 +448,7 @@ void freeIvarLists(Class aClass);
  */
 void freeMethodLists(Class aClass);
 
+#ifdef __cplusplus
+} // extern "C"
+#endif
 #endif //__OBJC_CLASS_H_INCLUDED


### PR DESCRIPTION
Move the weak references hash table to use a well-tested third-party
implementation instead of the hand-rolled version.