### PR TITLE
heap corruption in weakRef impl

### DIFF
--- a/arc.m
+++ b/arc.m
@@ -678,10 +678,6 @@ static BOOL loadWeakPointer(id *addr, id *obj, WeakRef **ref)
 	{
 		*ref = (WeakRef*)oldObj;
 		*obj = weakRefGetObj(*ref);
-		if(*obj == nil) {
-			*ref = NULL;
-			return NO;
-		}
 		return YES;
 	}
 	*ref = NULL;

--- a/arc.m
+++ b/arc.m
@@ -199,6 +199,8 @@ extern BOOL FastARCAutorelease;
 
 static BOOL useARCAutoreleasePool;
 
+static int weakref_class;
+
 static const long refcount_shift = 1;
 /**
  * We use the top bit of the reference count to indicate whether an object has
@@ -287,6 +289,10 @@ static inline id retain(id obj)
 	if (objc_test_class_flag(cls, objc_class_flag_fast_arc))
 	{
 		return objc_retain_fast_np(obj);
+	}
+	if ((Class)&weakref_class == cls) {
+		// compiler emit retain on weafRef
+		return obj;
 	}
 	return [obj retain];
 }
@@ -606,8 +612,6 @@ OBJC_PUBLIC id objc_storeStrong(id *addr, id value)
 ////////////////////////////////////////////////////////////////////////////////
 // Weak references
 ////////////////////////////////////////////////////////////////////////////////
-
-static int weakref_class;
 
 typedef struct objc_weak_ref
 {

--- a/arc.m
+++ b/arc.m
@@ -855,11 +855,6 @@ OBJC_PUBLIC id objc_loadWeakRetained(id* addr)
 	// will acquire the lock before attempting to deallocate)
 	if (obj == nil)
 	{
-		// If we've destroyed this weak ref, then make sure that we also deallocate the object.
-		if (weakRefRelease(ref))
-		{
-			*addr = nil;
-		}
 		return nil;
 	}
 	Class cls = classForObject(obj);

--- a/arc.m
+++ b/arc.m
@@ -678,6 +678,10 @@ static BOOL loadWeakPointer(id *addr, id *obj, WeakRef **ref)
 	{
 		*ref = (WeakRef*)oldObj;
 		*obj = weakRefGetObj(*ref);
+		if(*obj == nil) {
+			*ref = NULL;
+			return NO;
+		}
 		return YES;
 	}
 	*ref = NULL;


### PR DESCRIPTION
I don't think the isDeleted flag is getting checked when loading a weak pointer.  weakRefGetObj returns nil when flag is set, but loading the pointer doesn't care about it.

I'm not 100% sure this is correct, but our app has a whole bunch of issues without it.  