### PR TITLE
Fixed usage of properties linked list.

### DIFF
--- a/properties.m
+++ b/properties.m
@@ -302,7 +302,7 @@ objc_property_t* class_copyPropertyList(Class cls, unsigned int *outCount)
 	unsigned int out = 0;
 	for (struct objc_property_list *l=properties ; NULL!=l ; l=l->next)
 	{
-		for (int i=0 ; i<properties->count ; i++)
+		for (int i=0 ; i<l->count ; i++)
 		{
 			list[out++] = property_at_index(l, i);
 		}

--- a/protocol.c
+++ b/protocol.c
@@ -421,7 +421,7 @@ objc_property_t *protocol_copyPropertyList2(Protocol *p, unsigned int *outCount,
 	unsigned int count = 0;
 	for (struct objc_property_list *l=properties ; l!=NULL ; l=l->next)
 	{
-		count += properties->count;
+		count += l->count;
 	}
 	if (0 == count)
 	{


### PR DESCRIPTION
class_getProperty() and protocol_copyPropertyList() were using the wrong pointer when accessing the linked property list.