### PR TITLE
Added referenceCount to __cxa_exception struct and updated unwind alignment

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,11 +1,27 @@
 freebsd_instance:
   image: freebsd-12-0-release-amd64
 
-task:
+libcxxrt_freebsd_task:
   install_script: pkg install -y cmake ninja llvm80
-  script: |
+  build_script: |
       mkdir Build
       cd Build
       cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang80 -DCMAKE_CXX_COMPILER=clang++80
       ninja
-      ctest -j4
+  test_script: cd Build && ctest -j4
+
+libcxxrt_master_task:
+  install_script: pkg install -y git cmake ninja llvm80
+  install_libcxxrt_script: |
+      git clone https://github.com/libcxxrt/libcxxrt.git
+      mkdir -p libcxxrt/Build
+      cd libcxxrt/Build
+      cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang80 -DCMAKE_CXX_COMPILER=clang++80
+      ninja
+      cp lib/libcxxrt.so /usr/local/lib
+  build_script: |
+      mkdir Build
+      cd Build
+      cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang80 -DCMAKE_CXX_COMPILER=clang++80
+      ninja
+  test_script: cd Build && ctest -j4

--- a/objcxx_eh.cc
+++ b/objcxx_eh.cc
@@ -76,6 +76,9 @@ static BOOL isKindOfClass(Class thrown, Class type)
  */
 struct __cxa_exception
 {
+#if __LP64__
+	uintptr_t referenceCount;
+#endif
 	std::type_info *exceptionType;
 	void (*exceptionDestructor) (void *);
 	unexpected_handler unexpectedHandler;
@@ -91,6 +94,9 @@ struct __cxa_exception
 	const char *languageSpecificData;
 	void *catchTemp;
 	void *adjustedPtr;
+#if !__LP64__
+	uintptr_t referenceCount;
+#endif
 	_Unwind_Exception unwindHeader;
 };
 

--- a/unwind-arm.h
+++ b/unwind-arm.h
@@ -73,7 +73,7 @@ struct _Unwind_Exception
 	} pr_cache;
 	/** Force alignment of next item to 8-byte boundary */
 	long long int :0;
-};
+} __attribute__((__aligned__(8)));
 
 /* Unwinding functions */
 _Unwind_Reason_Code _Unwind_RaiseException(struct _Unwind_Exception *ucbp);

--- a/unwind-itanium.h
+++ b/unwind-itanium.h
@@ -78,8 +78,11 @@ struct _Unwind_Exception
   {
     uint64_t exception_class;
     _Unwind_Exception_Cleanup_Fn exception_cleanup;
-    unsigned long private_1;
-    unsigned long private_2;
+    uintptr_t private_1;
+    uintptr_t private_2;
+#if __SIZEOF_POINTER__ == 4
+    uint32_t reserved[3];
+#endif
   } __attribute__((__aligned__));
 
 extern _Unwind_Reason_Code _Unwind_RaiseException (struct _Unwind_Exception *);


### PR DESCRIPTION
Updated `__cxa_exception` to add `referenceCount` fields to match lates revisions from libcxxabi and libcxxrt:
https://github.com/llvm/llvm-project/blob/master/libcxxabi/src/cxa_exception.h#L30-L67
https://github.com/pathscale/libcxxrt/blob/master/src/cxxabi.h#L77-L165

Updated `_Unwind_Exception` structs to match latest revisions from libunwind:

- ARM version is using `__attribute__((__aligned__(8)))`:  
https://github.com/llvm/llvm-project/blob/master/libunwind/include/unwind.h#L107

- Itanium version is using `__attribute__((__aligned__))`, `uintptr_t` for private fields, and an added `reserved` field to be explicit about alignment:
https://github.com/llvm/llvm-project/blob/master/libunwind/include/unwind.h#L123-L143

The last two changes are also mirrored in this PR for libcxxrt:
https://github.com/libcxxrt/libcxxrt/pull/1

Fixes ObjCXXEHInterop tests on Android x86 and x86_64, as reported in #108. However, it does not yet fix the same test on Android ARMv7.