### PR TITLE
Match _Unwind_Reason_Code enum between ARM and Itanium.

### DIFF
--- a/unwind-arm.h
+++ b/unwind-arm.h
@@ -9,7 +9,7 @@
 	_URC_NO_REASON = 0,
 	_URC_OK = 0,                /* operation completed successfully */
 	_URC_FOREIGN_EXCEPTION_CAUGHT = 1,
-    _URC_END_OF_STACK = 5,
+	_URC_END_OF_STACK = 5,
 	_URC_HANDLER_FOUND = 6,
 	_URC_INSTALL_CONTEXT = 7,
 	_URC_CONTINUE_UNWIND = 8,
@@ -27,7 +27,7 @@ static const _Unwind_State _US_FORCE_UNWIND = 8;
 #	define _US_VIRTUAL_UNWIND_FRAME  0
 #	define _US_UNWIND_FRAME_STARTING 1
 #	define _US_UNWIND_FRAME_RESUME 2
-#   define _US_FORCE_UNWIND 8
+#	define _US_FORCE_UNWIND 8
 #endif
 
 typedef int _Unwind_Action;

--- a/unwind-arm.h
+++ b/unwind-arm.h
@@ -6,6 +6,7 @@
  */
  typedef enum
 {
+	_URC_NO_REASON = 0,
 	_URC_OK = 0,                /* operation completed successfully */
 	_URC_FOREIGN_EXCEPTION_CAUGHT = 1,
     _URC_END_OF_STACK = 5,

--- a/unwind-itanium.h
+++ b/unwind-itanium.h
@@ -40,6 +40,7 @@ extern "C" {
 typedef enum
   {
     _URC_NO_REASON = 0,
+    _URC_OK = 0,
     _URC_FOREIGN_EXCEPTION_CAUGHT = 1,
     _URC_FATAL_PHASE2_ERROR = 2,
     _URC_FATAL_PHASE1_ERROR = 3,


### PR DESCRIPTION
Unwind ARM was using `_URC_OK` and Itanium `_URC_NO_REASON`, which made it difficult to write code that worked with both versions. This adds the missing one to each, which matches what is done in libunwind:
https://github.com/llvm/llvm-project/blob/master/libunwind/include/unwind.h#L33-L34

Also fixes some mismatched in indentation.