### PR TITLE
Run FreeBSD CI also against libcxxrt master.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 freebsd_instance:
   image: freebsd-12-0-release-amd64
 
-task:
+libcxxrt_freebsd_task:
   install_script: pkg install -y cmake ninja llvm80 git
 
   clone_script: |
@@ -16,9 +16,41 @@ task:
     git submodule sync
     git submodule update
 
-  script: |
+  build_script: |
       mkdir Build
       cd Build
       cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang80 -DCMAKE_CXX_COMPILER=clang++80
       ninja
-      ctest -j4
+
+  test_script: cd Build && ctest -j4
+
+libcxxrt_master_task:
+  install_script: pkg install -y cmake ninja llvm80 git
+
+  clone_script: |
+    if [ -z "$CIRRUS_PR" ]; then
+      git clone --recursive --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+      git reset --hard $CIRRUS_CHANGE_IN_REPO
+    else
+      git clone --recursive https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+      git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+      git reset --hard $CIRRUS_CHANGE_IN_REPO
+    fi
+    git submodule sync
+    git submodule update
+
+  install_libcxxrt_script: |
+      git clone https://github.com/libcxxrt/libcxxrt.git
+      mkdir -p libcxxrt/Build
+      cd libcxxrt/Build
+      cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang80 -DCMAKE_CXX_COMPILER=clang++80
+      ninja
+      cp lib/libcxxrt.so /usr/local/lib
+
+  build_script: |
+      mkdir Build
+      cd Build
+      cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang80 -DCMAKE_CXX_COMPILER=clang++80
+      ninja
+
+  test_script: cd Build && ctest -j4


### PR DESCRIPTION
This updates the Cirrus CI script to to also build and test against the latest libcxxrt master in addition to libcxxrt bundled with FreeBSD 12.0.

Also moves running the tests to a separate phase so build and test logs are shown separately in the Cirrus CI UI.