### PR TITLE
generate a pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,21 @@ if (UNIX)
 endif ()
 include (CPack)
 
+# pkg-config descriptor
+
+if (BOEHM_GC)
+	set(PC_REQUIRES_PRIVATE_BOEHM_GC "Requires.private: bdw-gc")
+endif ()
+if (ENABLE_OBJCXX AND NOT CXXRT_IS_STDLIB)
+	set(PC_LIBS_PRIVATE "Libs.private: -l${CXX_RUNTIME}")
+endif()
+
+configure_file("libobjc.pc.in" "libobjc.pc" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libobjc.pc"
+	DESTINATION "${LIB_INSTALL_PATH}/pkgconfig"
+)
+
+
 # uninstall target
 configure_file(
 	"${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"

--- a/libobjc.pc.in
+++ b/libobjc.pc.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@LIB_INSTALL_PATH@
+includedir=${prefix}/@HEADER_INSTALL_PATH@
+
+Name: libobjc
+Description: GNUstep Objective-C runtime library
+Version: @CPACK_PACKAGE_VERSION_MAJOR@.@CPACK_PACKAGE_VERSION_MINOR@.@CPACK_PACKAGE_VERSION_PATCH@
+
+Cflags: -I${includedir}
+Libs: -L${libdir} -lobjc
+@PC_REQUIRES_PRIVATE_BOEHM_GC@
+@PC_LIBS_PRIVATE@


### PR DESCRIPTION
This is quite easy to do and allows build systems (even autoconf, if you want to call it a build system…) to discover a libobjc dependency more conveniently.