### PR TITLE
Fix #ifdef for class property test

### DIFF
--- a/Test/category_properties.m
+++ b/Test/category_properties.m
@@ -31,9 +31,9 @@ int main(int argc, char** argv)
 	prop = class_getProperty(test, "val2");
 	assert(prop);
 	assert(strcmp("Ti,R,D", property_getAttributes(prop)) == 0);
-#ifdef DGS_RUNTIME_V2
+#ifdef GS_RUNTIME_V2
 	test = object_getClass(test);
-	objc_property_t prop = class_getProperty(test, "val2");
+	prop = class_getProperty(test, "val2");
 	assert(prop);
 	assert(strcmp("Ti,R,D", property_getAttributes(prop)) == 0);
 #endif


### PR DESCRIPTION
Minor cleanup: The `#ifdef` was testing the wrong macro. 