### PR TITLE
Operate on the real weak ref table when erasing an entry

### DIFF
--- a/arc.mm
+++ b/arc.mm
@@ -850,7 +850,7 @@ extern "C" OBJC_PUBLIC BOOL objc_delete_weak_refs(id obj)
 			return NO;
 		}
 	}
-	auto table = weakRefs();
+	auto &table = weakRefs();
 	auto old = table.find(obj);
 	if (old != table.end())
 	{


### PR DESCRIPTION
This pull request reverts 336d8a8 and fixes the underlying issue properly. The real meat of the change is in dd35187.

It's not strictly necessary that we revert 336d8a8, but it looks like it added some extra bookkeeping that we only needed _because_ the map had dangling references. The tests that fail with 336d8a8 reverted _pass_ with dd35187.

Fixes #144.