### PR TITLE
Fix eh_win32_msvc.cc includes

### DIFF
--- a/eh_win32_msvc.cc
+++ b/eh_win32_msvc.cc
@@ -1,6 +1,6 @@
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstdio>
+#include <string>
 #include <vector>
 
 #include "objc/runtime.h"


### PR DESCRIPTION
When building on Windows using the latest Clang shipping with Visual Studio 2019 I’m getting the following errors:

```
../eh_win32_msvc.cc:65:13: error: no type named 'string' in namespace 'std'
static std::string mangleObjcObject()
       ~~~~~^
../eh_win32_msvc.cc:68:9: error: cannot initialize return object of type 'int' with an lvalue of type 'const char [19]'
        return ".PEAUobjc_object@@";
               ^~~~~~~~~~~~~~~~~~~~
../eh_win32_msvc.cc:74:13: error: no type named 'string' in namespace 'std'
static std::string mangleStructNamed(const char* className)
       ~~~~~^
../eh_win32_msvc.cc:83:8: error: no member named 'string' in namespace 'std'
                std::string(".PEAU") +
                ~~~~~^
```

Changing the "string.h" include to just "string" fixes the issues. I also updated the other two C includes to their C++ counterparts.

Not sure why it works in the CI, I’m guessing it must be a difference between the Visual Studio Clang build and the one from Chocolatey.