### PR TITLE
More EH fixes.

### DIFF
--- a/objcxx_eh.cc
+++ b/objcxx_eh.cc
@@ -266,7 +266,6 @@ namespace gnustep
 			                const __class_type_info *target,
 			                void **thrown_object) const
 			{
-				assert(0);
 				return false;
 			};
 		};


### PR DESCRIPTION
libsupc++ is more aggressive about internal consistency checks than
libcxxrt, so we need to be more careful in the interop.  The tests from
PR #138 now pass for me on Debian with libsupc++.