### PR TITLE
Add unwind COPY_EXCEPTION macro.

### DIFF
--- a/eh_personality.c
+++ b/eh_personality.c
@@ -568,13 +568,11 @@ BEGIN_PERSONALITY_FUNCTION(__gnustep_objcxx_personality_v0)
 		}
 		// We now have two copies of the _Unwind_Exception object (which stores
 		// state for the unwinder) in flight.  Make sure that they're in sync.
-		ex->cxx_exception->private_1 = exceptionObject->private_1;
-		ex->cxx_exception->private_2 = exceptionObject->private_2;
+		COPY_EXCEPTION(ex->cxx_exception, exceptionObject)
 		exceptionObject = ex->cxx_exception;
 		exceptionClass = cxx_exception_class;
 		int ret = CALL_PERSONALITY_FUNCTION(__gxx_personality_v0);
-		exceptionObject->private_1 = ex->cxx_exception->private_1;
-		exceptionObject->private_2 = ex->cxx_exception->private_2;
+		COPY_EXCEPTION(exceptionObject, ex->cxx_exception)
 		if (ret == _URC_INSTALL_CONTEXT)
 		{
 			get_thread_data()->cxxCaughtException = YES;

--- a/unwind-arm.h
+++ b/unwind-arm.h
@@ -201,3 +201,9 @@ _Unwind_Reason_Code name(_Unwind_State state,\
 	_Unwind_SetGR (context, 12, (unsigned long)exceptionObject);
 
 #define CALL_PERSONALITY_FUNCTION(name) name(state,exceptionObject,context)
+
+#define COPY_EXCEPTION(dst, src) \
+  memcpy((dst)->unwinder_cache, (src)->unwinder_cache, sizeof(struct unwinder_cache)); \
+  memcpy((dst)->barrier_cache, (src)->barrier_cache, sizeof(struct barrier_cache)); \
+  memcpy((dst)->cleanup_cache, (src)->cleanup_cache, sizeof(struct cleanup_cache)); \
+  memcpy((dst)->pr_cache, (src)->pr_cache, sizeof(struct pr_cache));

--- a/unwind-itanium.h
+++ b/unwind-itanium.h
@@ -164,6 +164,10 @@ _Unwind_Reason_Code name(int version,\
 
 #define CALL_PERSONALITY_FUNCTION(name) name(version, actions, exceptionClass, exceptionObject, context)
 
+#define COPY_EXCEPTION(dst, src) \
+  (dst)->private_1 = (src)->private_1; \
+  (dst)->private_2 = (src)->private_2;
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Allows copying Itanium and ARM exception objects as suggested in https://github.com/gnustep/libobjc2/issues/162#issuecomment-638776765.

Fixes #162.