### PR TITLE
Correctly copy inner exception structs when building for ARM.

### DIFF
--- a/unwind-arm.h
+++ b/unwind-arm.h
@@ -203,7 +203,7 @@ _Unwind_Reason_Code name(_Unwind_State state,\
 #define CALL_PERSONALITY_FUNCTION(name) name(state,exceptionObject,context)
 
 #define COPY_EXCEPTION(dst, src) \
-  memcpy((dst)->unwinder_cache, (src)->unwinder_cache, sizeof(struct unwinder_cache)); \
-  memcpy((dst)->barrier_cache, (src)->barrier_cache, sizeof(struct barrier_cache)); \
-  memcpy((dst)->cleanup_cache, (src)->cleanup_cache, sizeof(struct cleanup_cache)); \
-  memcpy((dst)->pr_cache, (src)->pr_cache, sizeof(struct pr_cache));
+  (dst)->unwinder_cache = (src)->unwinder_cache; \
+  (dst)->barrier_cache = (src)->barrier_cache; \
+  (dst)->cleanup_cache = (src)->cleanup_cache; \
+  (dst)->pr_cache = (src)->pr_cache;


### PR DESCRIPTION
I’m not sure why my previous change had seemingly worked before, while it clearly doesn’t as the inner structs are not named. We can instead simply ask the compiler to copy the structs instead of using memcpy.

Fixes #164.