### PR TITLE
Add pthreads to link libraries, not link flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,7 +353,7 @@ endif()
 # threading implementation (we do for everything except thread-local storage)
 set(CMAKE_THREAD_PREFER_PTHREAD)
 include(FindThreads)
-set(objc_LINK_FLAGS "${objc_LINK_FLAGS} ${CMAKE_THREAD_LIBS_INIT}")
+target_link_libraries(objc Threads::Threads)
 
 
 


### PR DESCRIPTION
This fixes linking errors with --as-needed like:
ld: libobjc.so.4.6: undefined reference to `pthread_mutexattr_destroy'

Fixes #180

The cmake target Threads::Threads support was apparently added in cmake 3.1 which is the minimum required version set in CMakeLists.txt