### PR TITLE
Increase testing matrix.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,38 +5,104 @@ jobs:
       vmImage: ubuntu-18.04
     strategy:
       matrix:
-        Debug:
+        Debug-64-llvm-8-libc++:
           BuildType: Debug
-          StdLib: libstdc++
-          CxxFlags: ""
-        Release:
+          Flags: -m64
+          StdLib: libc++
+          LLVM: -8
+        Release-64-llvm-8-libc++:
           BuildType: Release
-          StdLib: libstdc++
-          CxxFlags: ""
-        Debug-libc++:
+          Flags: -m64
+          StdLib: libc++
+          LLVM: -8
+        Debug-32-llvm-8-libc++:
           BuildType: Debug
+          Flags: -m32
           StdLib: libc++
-          CxxFlags: "-stdlib=libc++"
-        Release-libc++:
+          LLVM: -8
+        Release-32-llvm-8-libc++:
           BuildType: Release
+          Flags: -m32
           StdLib: libc++
-          CxxFlags: "-stdlib=libc++"
+          LLVM: -8
+        Debug-64-llvm-12-libc++:
+          BuildType: Debug
+          Flags: -m64
+          StdLib: libc++
+          LLVM: 
+        Release-64-llvm-12-libc++:
+          BuildType: Release
+          Flags: -m64
+          StdLib: libc++
+          LLVM: 
+        Debug-32-llvm-12-libc++:
+          BuildType: Debug
+          Flags: -m32
+          StdLib: libc++
+          LLVM: 
+        Release-32-llvm-12-libc++:
+          BuildType: Release
+          Flags: -m32
+          StdLib: libc++
+          LLVM: 
+        Debug-64-llvm-8-libstdc++:
+          BuildType: Debug
+          Flags: -m64
+          StdLib: libstdc++
+          LLVM: -8
+        Release-64-llvm-8-libstdc++:
+          BuildType: Release
+          Flags: -m64
+          StdLib: libstdc++
+          LLVM: -8
+        Debug-32-llvm-8-libstdc++:
+          BuildType: Debug
+          Flags: -m32
+          StdLib: libstdc++
+          LLVM: -8
+        Release-32-llvm-8-libstdc++:
+          BuildType: Release
+          Flags: -m32
+          StdLib: libstdc++
+          LLVM: -8
+        Debug-64-llvm-12-libstdc++:
+          BuildType: Debug
+          Flags: -m64
+          StdLib: libstdc++
+          LLVM: 
+        Release-64-llvm-12-libstdc++:
+          BuildType: Release
+          Flags: -m64
+          StdLib: libstdc++
+          LLVM: 
+        Debug-32-llvm-12-libstdc++:
+          BuildType: Debug
+          Flags: -m32
+          StdLib: libstdc++
+          LLVM: 
+        Release-32-llvm-12-libstdc++:
+          BuildType: Release
+          Flags: -m32
+          StdLib: libstdc++
+          LLVM: 
     steps:
     - checkout: self
       submodules: true
     - script: |
-        sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main"
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+        sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic$(LLVM) main"
         sudo apt-get update
-        sudo apt-get install -y ninja-build clang-8
+        sudo apt-get install -y ninja-build
+        sudo apt-get install -y -t llvm-toolchain-bionic$(LLVM) clang$(LLVM)
         if [ "$(StdLib)" = "libc++" ]; then
-          sudo apt-get install -qy libc++-8-dev libc++abi-8-dev
+          sudo apt-get install -y -t llvm-toolchain-bionic$(LLVM) libc++$(LLVM)-dev libc++abi$(LLVM)-dev
         fi
       displayName: Install Dependencies
 
     - task: CMake@1
       displayName: Generate Build Scripts
       inputs:
-        cmakeArgs: '.. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DTESTS=ON -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_FLAGS="$(CxxFlags)"'
+        cmakeArgs: '.. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DTESTS=ON -DCMAKE_CXX_COMPILER=clang++$(LLVM) -DCMAKE_C_COMPILER=clang$(LLVM) -DCMAKE_CXX_FLAGS="-stdlib=$(StdLib)"'
 
     - script: |
         ninja


### PR DESCRIPTION
Add 32-bit x86-Linux builds.
Add building with the nightly LLVM releases.  There are some regressions
since LLVM 8 that would have been caught by this that we can hopefully
fix in time for the LLVM 12 release.