### PR TITLE
Add support for MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,12 +79,12 @@ set(libBlocksRuntime_COMPATIBILITY_HDRS
 	Block.h
 	Block_private.h
 	)
-# Windows does not use DWARF EH
-if (WIN32)
+# Windows MSVC does not use DWARF EH
+if (MSVC)
 	list(APPEND libobjc_CXX_SRCS eh_win32_msvc.cc)
 else ()
 	list(APPEND libobjc_C_SRCS eh_personality.c)
-endif (WIN32)
+endif (MSVC)
 
 if (NOT EXISTS "${CMAKE_SOURCE_DIR}/third_party/robin-map/include/tsl/robin_map.h")
 	message(FATAL_ERROR "Git submodules not present, please run:\n\n"
@@ -279,7 +279,7 @@ endif()
 
 
 if (ENABLE_OBJCXX)
-	if (WIN32)
+	if (MSVC)
 		message(STATUS "Using MSVC-compatible exception model")
 	else ()
 		message(STATUS "Testing C++ interop")
@@ -322,8 +322,11 @@ if (ENABLE_OBJCXX)
 		if (CMAKE_CXX_COMPILER_TARGET)
 			list(APPEND EH_PERSONALITY_FLAGS "${CMAKE_CXX_COMPILE_OPTIONS_TARGET}${CMAKE_CXX_COMPILER_TARGET}")
 		endif ()
+		if (NOT WIN32)
+			list(APPEND EH_PERSONALITY_FLAGS "-fPIC")
+		endif ()
 		add_custom_command(OUTPUT eh_trampoline.s
-			COMMAND ${CMAKE_CXX_COMPILER} ARGS ${EH_PERSONALITY_FLAGS} -fPIC -S "${CMAKE_SOURCE_DIR}/eh_trampoline.cc" -o - -fexceptions -fno-inline | sed "s/__gxx_personality_v0/test_eh_personality/g" > "${CMAKE_BINARY_DIR}/eh_trampoline.s"
+			COMMAND ${CMAKE_CXX_COMPILER} ARGS ${EH_PERSONALITY_FLAGS} -S "${CMAKE_SOURCE_DIR}/eh_trampoline.cc" -o - -fexceptions -fno-inline | sed "s/__gxx_personality_v0/test_eh_personality/g" > "${CMAKE_BINARY_DIR}/eh_trampoline.s"
 			MAIN_DEPENDENCY eh_trampoline.cc)
 		list(APPEND libobjc_ASM_SRCS eh_trampoline.s)
 		list(APPEND libobjc_CXX_SRCS objcxx_eh.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,7 +326,7 @@ if (ENABLE_OBJCXX)
 			list(APPEND EH_PERSONALITY_FLAGS "-fPIC")
 		endif ()
 		add_custom_command(OUTPUT eh_trampoline.s
-			COMMAND ${CMAKE_CXX_COMPILER} ARGS ${EH_PERSONALITY_FLAGS} -S "${CMAKE_SOURCE_DIR}/eh_trampoline.cc" -o - -fexceptions -fno-inline | sed "s/__gxx_personality_v0/test_eh_personality/g" > "${CMAKE_BINARY_DIR}/eh_trampoline.s"
+			COMMAND ${CMAKE_CXX_COMPILER} ARGS ${EH_PERSONALITY_FLAGS} -S "${CMAKE_SOURCE_DIR}/eh_trampoline.cc" -o - -fexceptions -fno-inline | sed "s/__gxx_personality_v0/test_eh_personality/g" | sed "s/__gxx_personality_seh0/test_eh_personality/g" > "${CMAKE_BINARY_DIR}/eh_trampoline.s"
 			MAIN_DEPENDENCY eh_trampoline.cc)
 		list(APPEND libobjc_ASM_SRCS eh_trampoline.s)
 		list(APPEND libobjc_CXX_SRCS objcxx_eh.cc)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,49 +121,94 @@ jobs:
       inputs:
           testResultsFormat: cTest
           testResultsFiles: build/Testing/*/Test.xml
+
   - job: Windows
     displayName: Windows-2016
     pool:
       vmImage: vs2017-win2016
     strategy:
       matrix:
-        Debug-32:
+        MSVC-Debug-32:
           BuildType: Debug
           Arch: x64_x86
           Flags: -m32
-        Release-32:
+        MSVC-Release-32:
           BuildType: Release
           Arch: x64_x86
           Flags: -m32
-        Debug-64:
+        MSVC-Debug-64:
           BuildType: Debug
           Arch: x64
           Flags: -m64
-        Release-64:
+        MSVC-Release-64:
           BuildType: Release
           Arch: x64
           Flags: -m64
+        MinGW-Debug-32:
+          BuildType: Debug
+          Arch: i686
+          MSYSTEM: mingw32
+          LinkerFlags: -fuse-ld=lld
+        MinGW-Release-32:
+          BuildType: Release
+          Arch: i686
+          MSYSTEM: mingw32
+          LinkerFlags: -fuse-ld=lld
+        MinGW-Debug-64:
+          BuildType: Debug
+          Arch: x86_64
+          MSYSTEM: mingw64
+          LinkerFlags: -fuse-ld=lld
+        MinGW-Release-64:
+          BuildType: Release
+          Arch: x86_64
+          MSYSTEM: mingw64
+          LinkerFlags: -fuse-ld=lld
+    variables:
+      Flags:
+      LinkerFlags:
+      MSYS2_ROOT: $(System.Workfolder)\msys64
+      MinGW_Shell: '%MSYS2_ROOT%\msys2_shell.cmd -defterm -no-start -%MSYSTEM% -full-path -here -c'
     steps:
     - checkout: self
       submodules: true
     - script: |
-        choco.exe install ninja
-        choco.exe install llvm
-
-
+        IF DEFINED MSYSTEM (
+          echo Installing MSYS2...
+          choco.exe install --no-progress --params="/InstallDir:$(MSYS2_ROOT)" msys2
+          echo Installing packages...
+          $(MSYS2_ROOT)\usr\bin\pacman --noconfirm --needed -S ^
+            mingw-w64-$(Arch)-cmake ^
+            mingw-w64-$(Arch)-ninja ^
+            mingw-w64-$(Arch)-clang ^
+            mingw-w64-$(Arch)-lld
+          echo Setting PATH for subsequent tasks...
+          echo "##vso[task.setvariable variable=PATH]$(MSYS2_ROOT)\$(MSYSTEM)\bin;%PATH%"
+        ) else (
+          choco.exe install --no-progress ninja
+          choco.exe install --no-progress llvm
+        )
+      displayName: 'Install Dependencies'
 
     - script: |
         echo Creating build directory...
         mkdir build
         cd build
-        echo Importing visual studio environment variables...
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat" $(Arch)
-        echo Checking that we're calling the correct link.exe
-        where link.exe
+        IF DEFINED MSYSTEM (
+          set CC=clang
+          set CXX=clang++
+        ) else (
+          echo Importing visual studio environment variables...
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat" $(Arch)
+          echo Checking that we're calling the correct link.exe
+          where link.exe
+          set "CC=C:/Program Files/LLVM/bin/clang-cl.exe"
+          set "CXX=C:/Program Files/LLVM/bin/clang-cl.exe"
+        )
         set CFLAGS=$(Flags)
         set CXXFLAGS=$(Flags)
         echo Running cmake...
-        cmake .. -G Ninja -DTESTS=ON -DCMAKE_C_COMPILER="c:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_CXX_COMPILER="c:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_BUILD_TYPE=$(BuildType)
+        cmake .. -G Ninja -DTESTS=ON -DCMAKE_C_COMPILER="%CC%" -DCMAKE_CXX_COMPILER="%CXX%" -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_SHARED_LINKER_FLAGS=$(LinkerFlags) -DCMAKE_EXE_LINKER_FLAGS=$(LinkerFlags)
         echo CMake completed.
 
       failOnStderr: false
@@ -171,11 +216,16 @@ jobs:
 
     - script: |
         cd build
-        echo Importing visual studio environment variables...
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat" $(Arch)
-        set CCC_OVERRIDE_OPTIONS=x-TC x-TP x/TC x/TP
-        echo Running ninja...
-        ninja
+        IF DEFINED MSYSTEM (
+          echo Running ninja...
+          $(MinGW_Shell) "ninja"
+        ) else (
+          echo Importing visual studio environment variables...
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat" $(Arch)
+          set CCC_OVERRIDE_OPTIONS=x-TC x-TP x/TC x/TP
+          echo Running ninja...
+          ninja
+        )
         echo Ninja completed.
 
       failOnStderr: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,30 +144,29 @@ jobs:
           BuildType: Release
           Arch: x64
           Flags: -m64
-        MinGW-Debug-32:
-          BuildType: Debug
-          Arch: i686
-          MSYSTEM: mingw32
-          LinkerFlags: -fuse-ld=lld
-        MinGW-Release-32:
-          BuildType: Release
-          Arch: i686
-          MSYSTEM: mingw32
-          LinkerFlags: -fuse-ld=lld
-        MinGW-Debug-64:
+        MSYS2-CLANG64-Debug-32:
           BuildType: Debug
           Arch: x86_64
-          MSYSTEM: mingw64
-          LinkerFlags: -fuse-ld=lld
-        MinGW-Release-64:
+          Flags: -m32
+          MSYSTEM: clang64
+        MSYS2-CLANG64-Release-32:
           BuildType: Release
           Arch: x86_64
-          MSYSTEM: mingw64
-          LinkerFlags: -fuse-ld=lld
+          Flags: -m32
+          MSYSTEM: clang64
+        MSYS2-CLANG64-Debug-64:
+          BuildType: Debug
+          Arch: x86_64
+          Flags: -m64
+          MSYSTEM: clang64
+        MSYS2-CLANG64-Release-64:
+          BuildType: Release
+          Arch: x86_64
+          Flags: -m64
+          MSYSTEM: clang64
     variables:
       Flags:
-      LinkerFlags:
-      MSYS2_ROOT: $(System.Workfolder)\msys64
+      MSYS2_ROOT: $(System.Workfolder)\msys2
       MinGW_Shell: '%MSYS2_ROOT%\msys2_shell.cmd -defterm -no-start -%MSYSTEM% -full-path -here -c'
     steps:
     - checkout: self
@@ -178,10 +177,9 @@ jobs:
           choco.exe install --no-progress --params="/InstallDir:$(MSYS2_ROOT)" msys2
           echo Installing packages...
           $(MSYS2_ROOT)\usr\bin\pacman --noconfirm --needed -S ^
-            mingw-w64-$(Arch)-cmake ^
-            mingw-w64-$(Arch)-ninja ^
-            mingw-w64-$(Arch)-clang ^
-            mingw-w64-$(Arch)-lld
+            mingw-w64-clang-$(Arch)-cmake ^
+            mingw-w64-clang-$(Arch)-ninja ^
+            mingw-w64-clang-$(Arch)-toolchain
           echo Setting PATH for subsequent tasks...
           echo "##vso[task.setvariable variable=PATH]$(MSYS2_ROOT)\$(MSYSTEM)\bin;%PATH%"
         ) else (
@@ -208,7 +206,7 @@ jobs:
         set CFLAGS=$(Flags)
         set CXXFLAGS=$(Flags)
         echo Running cmake...
-        cmake .. -G Ninja -DTESTS=ON -DCMAKE_C_COMPILER="%CC%" -DCMAKE_CXX_COMPILER="%CXX%" -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_SHARED_LINKER_FLAGS=$(LinkerFlags) -DCMAKE_EXE_LINKER_FLAGS=$(LinkerFlags)
+        cmake .. -G Ninja -DTESTS=ON -DCMAKE_C_COMPILER="%CC%" -DCMAKE_CXX_COMPILER="%CXX%" -DCMAKE_BUILD_TYPE=$(BuildType)
         echo CMake completed.
 
       failOnStderr: false

--- a/eh_personality.c
+++ b/eh_personality.c
@@ -7,6 +7,14 @@
 #include "class.h"
 #include "objcxx_eh.h"
 
+#if defined(__SEH__) && !defined(__USING_SJLJ_EXCEPTIONS__)
+#include <windows.h>
+#include <winnt.h>
+
+EXCEPTION_DISPOSITION _GCC_specific_handler(PEXCEPTION_RECORD, void *, PCONTEXT,
+                                            PDISPATCHER_CONTEXT, void *);
+#endif
+
 #ifndef DEBUG_EXCEPTIONS
 #define DEBUG_LOG(...)
 #else
@@ -583,6 +591,16 @@ BEGIN_PERSONALITY_FUNCTION(__gnustep_objcxx_personality_v0)
 #endif
 	return CALL_PERSONALITY_FUNCTION(__gxx_personality_v0);
 }
+
+#if defined(__SEH__) && !defined(__USING_SJLJ_EXCEPTIONS__)
+EXCEPTION_DISPOSITION
+__gnu_objc_personality_seh0(PEXCEPTION_RECORD ms_exc, void *this_frame,
+		PCONTEXT ms_orig_context, PDISPATCHER_CONTEXT ms_disp)
+{
+	return _GCC_specific_handler(ms_exc, this_frame, ms_orig_context, ms_disp,
+			__gnustep_objc_personality_v0);
+}
+#endif
 
 id objc_begin_catch(struct _Unwind_Exception *exceptionObject)
 {

--- a/eh_personality.c
+++ b/eh_personality.c
@@ -13,6 +13,7 @@
 
 EXCEPTION_DISPOSITION _GCC_specific_handler(PEXCEPTION_RECORD, void *, PCONTEXT,
                                             PDISPATCHER_CONTEXT, void *);
+DECLARE_PERSONALITY_FUNCTION(test_eh_personality_internal);
 #endif
 
 #ifndef DEBUG_EXCEPTIONS
@@ -192,7 +193,7 @@ static void cleanup(_Unwind_Reason_Code reason, struct _Unwind_Exception *e)
 					*/
 }
 
-void objc_exception_rethrow(struct _Unwind_Exception *e);
+OBJC_PUBLIC void objc_exception_rethrow(struct _Unwind_Exception *e);
 
 /**
  * Throws an Objective-C exception.  This function is, unfortunately, used for
@@ -603,6 +604,13 @@ __gnu_objc_personality_seh0(PEXCEPTION_RECORD ms_exc, void *this_frame,
 {
 	return _GCC_specific_handler(ms_exc, this_frame, ms_orig_context, ms_disp,
 			__gnustep_objc_personality_v0);
+}
+PRIVATE EXCEPTION_DISPOSITION
+test_eh_personality(PEXCEPTION_RECORD ms_exc, void *this_frame,
+		PCONTEXT ms_orig_context, PDISPATCHER_CONTEXT ms_disp)
+{
+	return _GCC_specific_handler(ms_exc, this_frame, ms_orig_context, ms_disp,
+			test_eh_personality_internal);
 }
 #endif
 

--- a/eh_personality.c
+++ b/eh_personality.c
@@ -400,7 +400,10 @@ static inline _Unwind_Reason_Code internal_objc_personality(int version,
 #ifndef NO_OBJCXX
 	if (cxx_exception_class == 0)
 	{
+#ifndef __SEH__
+		// FIXME: This is currently broken with MinGW
 		test_cxx_eh_implementation();
+#endif
 	}
 
 	if (exceptionClass == cxx_exception_class)
@@ -582,11 +585,11 @@ BEGIN_PERSONALITY_FUNCTION(__gnustep_objcxx_personality_v0)
 		}
 		// We now have two copies of the _Unwind_Exception object (which stores
 		// state for the unwinder) in flight.  Make sure that they're in sync.
-		COPY_EXCEPTION(ex->cxx_exception, exceptionObject)
+		COPY_EXCEPTION(ex->cxx_exception, exceptionObject);
 		exceptionObject = ex->cxx_exception;
 		exceptionClass = cxx_exception_class;
 		int ret = CALL_PERSONALITY_FUNCTION(__gxx_personality_v0);
-		COPY_EXCEPTION(exceptionObject, ex->cxx_exception)
+		COPY_EXCEPTION(exceptionObject, ex->cxx_exception);
 		if (ret == _URC_INSTALL_CONTEXT)
 		{
 			get_thread_data()->cxxCaughtException = YES;

--- a/eh_personality.c
+++ b/eh_personality.c
@@ -553,15 +553,19 @@ static inline _Unwind_Reason_Code internal_objc_personality(int version,
 	return _URC_INSTALL_CONTEXT;
 }
 
+OBJC_PUBLIC
 BEGIN_PERSONALITY_FUNCTION(__gnu_objc_personality_v0)
 	return internal_objc_personality(version, actions, exceptionClass,
 			exceptionObject, context, NO);
 }
+
+OBJC_PUBLIC
 BEGIN_PERSONALITY_FUNCTION(__gnustep_objc_personality_v0)
 	return internal_objc_personality(version, actions, exceptionClass,
 			exceptionObject, context, YES);
 }
 
+OBJC_PUBLIC
 BEGIN_PERSONALITY_FUNCTION(__gnustep_objcxx_personality_v0)
 #ifndef NO_OBJCXX
 	if (cxx_exception_class == 0)
@@ -593,7 +597,7 @@ BEGIN_PERSONALITY_FUNCTION(__gnustep_objcxx_personality_v0)
 }
 
 #if defined(__SEH__) && !defined(__USING_SJLJ_EXCEPTIONS__)
-EXCEPTION_DISPOSITION
+OBJC_PUBLIC EXCEPTION_DISPOSITION
 __gnu_objc_personality_seh0(PEXCEPTION_RECORD ms_exc, void *this_frame,
 		PCONTEXT ms_orig_context, PDISPATCHER_CONTEXT ms_disp)
 {

--- a/eh_personality.c
+++ b/eh_personality.c
@@ -199,7 +199,7 @@ void objc_exception_rethrow(struct _Unwind_Exception *e);
  * rethrowing caught exceptions too, even in @finally() blocks.  Unfortunately,
  * this means that we have some problems if the exception is boxed.
  */
-void objc_exception_throw(id object)
+OBJC_PUBLIC void objc_exception_throw(id object)
 {
 	struct thread_data *td = get_thread_data();
 	DEBUG_LOG("Throwing %p, in flight exception: %p\n", object, td->lastThrownObject);
@@ -543,9 +543,9 @@ static inline _Unwind_Reason_Code internal_objc_personality(int version,
 		}
 	}
 
-	_Unwind_SetIP(context, (unsigned long)action.landing_pad);
+	_Unwind_SetIP(context, (uintptr_t)action.landing_pad);
 	_Unwind_SetGR(context, __builtin_eh_return_data_regno(0), 
-			(unsigned long)(isNew ? exceptionObject : object));
+			(uintptr_t)(isNew ? exceptionObject : object));
 	_Unwind_SetGR(context, __builtin_eh_return_data_regno(1), selector);
 
 	DEBUG_LOG("Installing context, selector %d\n", (int)selector);
@@ -606,7 +606,7 @@ __gnu_objc_personality_seh0(PEXCEPTION_RECORD ms_exc, void *this_frame,
 }
 #endif
 
-id objc_begin_catch(struct _Unwind_Exception *exceptionObject)
+OBJC_PUBLIC id objc_begin_catch(struct _Unwind_Exception *exceptionObject)
 {
 	struct thread_data *td = get_thread_data();
 	DEBUG_LOG("Beginning catch %p\n", exceptionObject);
@@ -678,7 +678,7 @@ id objc_begin_catch(struct _Unwind_Exception *exceptionObject)
 	return (id)((char*)exceptionObject + sizeof(struct _Unwind_Exception));
 }
 
-void objc_end_catch(void)
+OBJC_PUBLIC void objc_end_catch(void)
 {
 	struct thread_data *td = get_thread_data_fast();
 	// If this is a boxed foreign exception then the boxing class is
@@ -724,7 +724,7 @@ void objc_end_catch(void)
 	}
 }
 
-void objc_exception_rethrow(struct _Unwind_Exception *e)
+OBJC_PUBLIC void objc_exception_rethrow(struct _Unwind_Exception *e)
 {
 	struct thread_data *td = get_thread_data_fast();
 	// If this is an Objective-C exception, then 

--- a/objc_msgSend.x86-32.S
+++ b/objc_msgSend.x86-32.S
@@ -37,7 +37,7 @@
 	test  %eax, %eax
 	jz    5f                             # Nil slot - invoke some kind of forwarding mechanism
 	mov   SLOT_OFFSET(%eax), %ecx
-#ifdef _WIN32
+#ifdef _MSC_VER
 	call  *CDECL(__guard_check_icall_fptr)
 #endif
 	jmp   *%ecx
@@ -62,7 +62,7 @@
 	add   $12, %esp                      # restore the stack
 
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 	mov    %eax, %ecx
 	call  *CDECL(__guard_check_icall_fptr)
 	jmp   *%ecx

--- a/objc_msgSend.x86-32.S
+++ b/objc_msgSend.x86-32.S
@@ -126,7 +126,13 @@ CDECL(objc_msgSend_stret):
 
 #ifdef _WIN32
         .section        .drectve,"yn"
+#ifdef _MSC_VER
         .ascii  " /EXPORT:_objc_msgSend"
         .ascii  " /EXPORT:_objc_msgSend_stret"
         .ascii  " /EXPORT:_objc_msgSend_fpret"
+#else
+        .ascii  " /EXPORT:objc_msgSend"
+        .ascii  " /EXPORT:objc_msgSend_stret"
+        .ascii  " /EXPORT:objc_msgSend_fpret"
+#endif
 #endif

--- a/objc_msgSend.x86-64.S
+++ b/objc_msgSend.x86-64.S
@@ -193,7 +193,7 @@
 
 12:
 #endif // WITH_TRACING
-#ifdef _WIN64
+#ifdef _MSC_VER
 	mov   %r10, %rax
 	jmp   *__guard_dispatch_icall_fptr(%rip)
 #else

--- a/objcxx_eh.cc
+++ b/objcxx_eh.cc
@@ -448,7 +448,11 @@ PRIVATE void cxx_throw()
  */
 extern "C"
 PRIVATE
+#ifdef __SEH__
+BEGIN_PERSONALITY_FUNCTION(test_eh_personality_internal)
+#else
 BEGIN_PERSONALITY_FUNCTION(test_eh_personality)
+#endif
 	// Don't bother with a mutex here.  It doesn't matter if two threads set
 	// these values at the same time.
 	if (!done_setup)

--- a/objcxx_eh.cc
+++ b/objcxx_eh.cc
@@ -448,7 +448,7 @@ PRIVATE void cxx_throw()
  */
 extern "C"
 PRIVATE
-#ifdef __SEH__
+#if defined(__SEH__) && !defined(__USING_SJLJ_EXCEPTIONS__)
 BEGIN_PERSONALITY_FUNCTION(test_eh_personality_internal)
 #else
 BEGIN_PERSONALITY_FUNCTION(test_eh_personality)

--- a/objcxx_eh.cc
+++ b/objcxx_eh.cc
@@ -218,7 +218,7 @@ namespace gnustep
 		/**
 		 * Superclass for the type info for Objective-C exceptions.
 		 */
-		struct __objc_type_info : std::type_info
+		struct OBJC_PUBLIC __objc_type_info : std::type_info
 		{
 			/**
 			 * Constructor that sets the name.
@@ -266,7 +266,7 @@ namespace gnustep
 		/**
 		 * Singleton type info for the `id` type.
 		 */
-		struct __objc_id_type_info : __objc_type_info
+		struct OBJC_PUBLIC __objc_id_type_info : __objc_type_info
 		{
 			/**
 			 * The `id` type is mangled to `@id`, which is not a valid mangling
@@ -278,7 +278,7 @@ namespace gnustep
 			                        void **obj,
 			                        unsigned outer) const;
 		};
-		struct __objc_class_type_info : __objc_type_info
+		struct OBJC_PUBLIC __objc_class_type_info : __objc_type_info
 		{
 			virtual ~__objc_class_type_info();
 			virtual bool __do_catch(const type_info *thrownType,

--- a/unwind-itanium.h
+++ b/unwind-itanium.h
@@ -88,13 +88,13 @@ extern _Unwind_Reason_Code _Unwind_ForcedUnwind (struct _Unwind_Exception *,
 						 _Unwind_Stop_Fn, void *);
 extern void _Unwind_Resume (struct _Unwind_Exception *);
 extern void _Unwind_DeleteException (struct _Unwind_Exception *);
-extern unsigned long _Unwind_GetGR (struct _Unwind_Context *, int);
-extern void _Unwind_SetGR (struct _Unwind_Context *, int, unsigned long);
-extern unsigned long _Unwind_GetIP (struct _Unwind_Context *);
-extern unsigned long _Unwind_GetIPInfo (struct _Unwind_Context *, int *);
-extern void _Unwind_SetIP (struct _Unwind_Context *, unsigned long);
-extern unsigned long _Unwind_GetLanguageSpecificData (struct _Unwind_Context*);
-extern unsigned long _Unwind_GetRegionStart (struct _Unwind_Context *);
+extern uintptr_t _Unwind_GetGR (struct _Unwind_Context *, int);
+extern void _Unwind_SetGR (struct _Unwind_Context *, int, uintptr_t);
+extern uintptr_t _Unwind_GetIP (struct _Unwind_Context *);
+extern uintptr_t _Unwind_GetIPInfo (struct _Unwind_Context *, int *);
+extern void _Unwind_SetIP (struct _Unwind_Context *, uintptr_t);
+extern uintptr_t _Unwind_GetLanguageSpecificData (struct _Unwind_Context*);
+extern uintptr_t _Unwind_GetRegionStart (struct _Unwind_Context *);
 
 #ifdef _GNU_SOURCE
 
@@ -115,17 +115,17 @@ extern _Unwind_Reason_Code
 
 /* See http://gcc.gnu.org/ml/gcc-patches/2003-09/msg00154.html for why
    _Unwind_GetBSP() exists.  */
-extern unsigned long _Unwind_GetBSP (struct _Unwind_Context *);
+extern uintptr_t _Unwind_GetBSP (struct _Unwind_Context *);
 
 /* Return the "canonical frame address" for the given context.
    This is used by NPTL... */
-extern unsigned long _Unwind_GetCFA (struct _Unwind_Context *);
+extern uintptr_t _Unwind_GetCFA (struct _Unwind_Context *);
 
 /* Return the base-address for data references.  */
-extern unsigned long _Unwind_GetDataRelBase (struct _Unwind_Context *);
+extern uintptr_t _Unwind_GetDataRelBase (struct _Unwind_Context *);
 
 /* Return the base-address for text references.  */
-extern unsigned long _Unwind_GetTextRelBase (struct _Unwind_Context *);
+extern uintptr_t _Unwind_GetTextRelBase (struct _Unwind_Context *);
 
 /* Call _Unwind_Trace_Fn once for each stack-frame, without doing any
    cleanup.  The first frame for which the callback is invoked is the

--- a/unwind-itanium.h
+++ b/unwind-itanium.h
@@ -79,8 +79,12 @@ struct _Unwind_Exception
   {
     uint64_t exception_class;
     _Unwind_Exception_Cleanup_Fn exception_cleanup;
+#ifdef __SEH__
+    uintptr_t private_[6];
+#else
     uintptr_t private_1;
     uintptr_t private_2;
+#endif
   } __attribute__((__aligned__));
 
 extern _Unwind_Reason_Code _Unwind_RaiseException (struct _Unwind_Exception *);
@@ -164,9 +168,18 @@ _Unwind_Reason_Code name(int version,\
 
 #define CALL_PERSONALITY_FUNCTION(name) name(version, actions, exceptionClass, exceptionObject, context)
 
+#ifdef __SEH__
 #define COPY_EXCEPTION(dst, src) \
-  (dst)->private_1 = (src)->private_1; \
-  (dst)->private_2 = (src)->private_2;
+  do {                                                                 \
+    memcpy((dst)->private_, (src)->private_, sizeof((src)->private_)); \
+  } while(0)
+#else
+#define COPY_EXCEPTION(dst, src) \
+  do {                                   \
+    (dst)->private_1 = (src)->private_1; \
+    (dst)->private_2 = (src)->private_2; \
+  } while(0)
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
These are some first steps to add support for MinGW, which was outlined by David as follows:

1. Make libobjc2 build in a MinGW environment (and add MinGW to the test matrix eventually, though not until we’ve had a new LLVM release).
2. Make it build the *NIX version of the exception handling code, not the Windows version, when targeting MinGW.
3. Add a __gnustep_objc_personality_seh0 that calls _GCC_specific_handler, passing __gnustep_objc_personality_v0 as the last parameter (see: https://reviews.llvm.org/D49638).
4. Modify clang using the patch to only use Windows native exceptions with an MSVC target triple and to use __gnustep_objc_personality_seh0 instead of the Windows C++ exception handler.

These patches do 1–3 above, including adding MinGW to CI using MSYS2 and the latest official Clang 11 from MSYS2 packages. This allows building the DLL in an MinGW environment, although building the tests currently expectantly [fails on CI](https://dev.azure.com/gnustep/libobjc2/_build/results?buildId=417&view=logs&j=67876ce3-30b9-5448-5fc3-54389d468f68&t=ade0b31a-3de8-5b67-0002-91e5e59dffce&l=96) with the following errors (other tests involving exceptions fail with the same linker errors minus the vtable one):

```
FAILED: Test/ObjCXXEHInterop.exe 
cmd.exe /C "cd . && D:\a\msys64\mingw64\bin\clang.exe -Xclang -fexceptions -Xclang -fobjc-exceptions -O0 -Xclang -fno-inline -g -fuse-ld=lld Test/CMakeFiles/test_runtime.dir/Test.m.obj Test/CMakeFiles/ObjCXXEHInterop.dir/ObjCXXEHInterop.mm.obj Test/CMakeFiles/ObjCXXEHInterop.dir/ObjCXXEHInterop.m.obj -o Test\ObjCXXEHInterop.exe -Wl,--major-image-version,0,--minor-image-version,0  libobjc.dll.a  -lstdc++  -lgcc_s  -lgcc_s  -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 && cd ."
lld-link: error: undefined symbol: objc_exception_throw
>>> referenced by ../Test\ObjCXXEHInterop.mm:33
>>>               Test/CMakeFiles/ObjCXXEHInterop.dir/ObjCXXEHInterop.mm.obj:(poke_objcxx)
>>> referenced by ../Test\ObjCXXEHInterop.m:10
>>>               Test/CMakeFiles/ObjCXXEHInterop.dir/ObjCXXEHInterop.m.obj:(rethrow)

lld-link: error: undefined symbol: vtable for gnustep::libobjc::__objc_class_type_info
>>> referenced by Test/CMakeFiles/ObjCXXEHInterop.dir/ObjCXXEHInterop.mm.obj:(.weak.__objc_eh_typeinfo_Test.default.check_uncaught_count)

lld-link: error: undefined symbol: objc_begin_catch
>>> referenced by ../Test\ObjCXXEHInterop.m:19
>>>               Test/CMakeFiles/ObjCXXEHInterop.dir/ObjCXXEHInterop.m.obj:(main)

lld-link: error: undefined symbol: objc_end_catch
>>> referenced by ../Test\ObjCXXEHInterop.m:21
>>>               Test/CMakeFiles/ObjCXXEHInterop.dir/ObjCXXEHInterop.m.obj:(main)
>>> referenced by ../Test\ObjCXXEHInterop.m:21
>>>               Test/CMakeFiles/ObjCXXEHInterop.dir/ObjCXXEHInterop.m.obj:(main)
```

I’m unsure about the vtable issue, but I think fixing the other missing symbols requires patching Clang. I’m basically just running blind here as I have no knowledge of Clang internals, but I tried the following patch based on David’s patches sent on the mailing list, replacing `EHPersonality::MSVC_CxxFrameHandler3` with `EHPersonality::GNU_ObjC_SEH`.

```patch
--- a/lib/CodeGen/CGObjCGNU.cpp
+++ b/lib/CodeGen/CGObjCGNU.cpp
@@ -2137,8 +2137,7 @@
     ProtocolVersion(protocolClassVersion), ClassABIVersion(classABI) {

   msgSendMDKind = VMContext.getMDKindID("GNUObjCMessageSend");
-  usesSEHExceptions =
-      cgm.getContext().getTargetInfo().getTriple().isWindowsMSVCEnvironment();
+  usesSEHExceptions = cgm.getLangOpts().SEHExceptions;

   CodeGenTypes &Types = CGM.getTypes();
   IntTy = cast<llvm::IntegerType>(
--- a/lib/CodeGen/CGException.cpp
+++ b/lib/CodeGen/CGException.cpp
@@ -142,6 +142,8 @@
   case ObjCRuntime::WatchOS:
     return EHPersonality::NeXT_ObjC;
   case ObjCRuntime::GNUstep:
+    if (L.SEHExceptions)
+      return EHPersonality::GNU_ObjC_SEH;
     if (L.ObjCRuntime.getVersion() >= VersionTuple(1, 7))
       return EHPersonality::GNUstep_ObjC;
     LLVM_FALLTHROUGH;
@@ -194,6 +196,8 @@
     return getObjCPersonality(Target, L);
 
   case ObjCRuntime::GNUstep:
+    if (L.SEHExceptions)
+      return EHPersonality::GNU_ObjC_SEH;
     return EHPersonality::GNU_ObjCXX;
 
   // The GCC runtime's personality function inherently doesn't support
```

This fixes the `objc_begin_catch`/`objc_end_catch` errors, but not `objc_exception_throw` and adds some new errors involving the standard library:
```
FAILED: Test/ObjCXXEHInterop.exe
cmd.exe /C "cd . && C:\msys64\mingw64\bin\clang.exe -Xclang -fexceptions -Xclang -fobjc-exceptions -fuse-ld=lld Test/CMakeFiles/test_runtime.dir/Test.m.obj Test/CMakeFiles/ObjCXXEHInterop.dir/ObjCXXEHInterop.mm.obj Test/CMakeFiles/ObjCXXEHInterop.dir/ObjCXXEHInterop.m.obj -o Test\ObjCXXEHInterop.exe -Wl,--major-image-version,0,--minor-image-version,0  libobjc.dll.a  C:/msys64/usr/lib/libm.a  -lstdc++  -lgcc_s  -lgcc_s  -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 && cd ."
lld-link: error: undefined symbol: objc_exception_throw
>>> referenced by Test/CMakeFiles/ObjCXXEHInterop.dir/ObjCXXEHInterop.mm.obj:(poke_objcxx)
>>> referenced by Test/CMakeFiles/ObjCXXEHInterop.dir/ObjCXXEHInterop.m.obj:(rethrow)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[138/214] Linking C executable Test\objc_msgSend.exe
FAILED: Test/objc_msgSend.exe
cmd.exe /C "cd . && C:\msys64\mingw64\bin\clang.exe -Xclang -fexceptions -Xclang -fobjc-exceptions -fuse-ld=lld Test/CMakeFiles/test_runtime.dir/Test.m.obj Test/CMakeFiles/objc_msgSend.dir/objc_msgSend.m.obj -o Test\objc_msgSend.exe -Wl,--major-image-version,0,--minor-image-version,0  libobjc.dll.a  C:/msys64/usr/lib/libm.a  -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 && cd ."
lld-link: error: undefined symbol: objc_exception_throw
>>> referenced by Test/CMakeFiles/objc_msgSend.dir/objc_msgSend.m.obj:(_c_MsgTest__initialize)

lld-link: error: undefined symbol: vtable for __cxxabiv1::__class_type_info
>>> referenced by Test/CMakeFiles/objc_msgSend.dir/objc_msgSend.m.obj:(typeinfo for objc_object)

lld-link: error: undefined symbol: vtable for __cxxabiv1::__pointer_type_info
>>> referenced by Test/CMakeFiles/objc_msgSend.dir/objc_msgSend.m.obj:(typeinfo for objc_object*)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[141/214] Linking C executable Test\NilException.exe
```

Note that the above is using libstdc++. I’m not sure if that’s what we want to use here – I also tried using libc++, which required some patching for the typeinfo test to work, but this resulted in the following errors linking the DLL:
```
FAILED: libobjc.dll libobjc.dll.a
cmd.exe /C "cd . && C:\msys64\mingw64\bin\clang.exe -Xclang -fexceptions -Xclang -fobjc-exceptions  -fuse-ld=lld -shared -o libobjc.dll -Wl,--out-implib,libobjc.dll.a -Wl,--major-image-version,0,--minor-image-version,0 CMakeFiles/objc.dir/alias_table.c.obj CMakeFiles/objc.dir/block_to_imp.c.obj CMakeFiles/objc.dir/caps.c.obj CMakeFiles/objc.dir/category_loader.c.obj CMakeFiles/objc.dir/class_table.c.obj CMakeFiles/objc.dir/dtable.c.obj CMakeFiles/objc.dir/encoding2.c.obj CMakeFiles/objc.dir/hooks.c.obj CMakeFiles/objc.dir/ivar.c.obj CMakeFiles/objc.dir/loader.c.obj CMakeFiles/objc.dir/mutation.m.obj CMakeFiles/objc.dir/protocol.c.obj CMakeFiles/objc.dir/runtime.c.obj CMakeFiles/objc.dir/sarray2.c.obj CMakeFiles/objc.dir/selector_table.c.obj CMakeFiles/objc.dir/sendmsg2.c.obj CMakeFiles/objc.dir/eh_personality.c.obj CMakeFiles/objc.dir/block_trampolines.S.obj CMakeFiles/objc.dir/objc_msgSend.S.obj CMakeFiles/objc.dir/eh_trampoline.s.obj CMakeFiles/objc.dir/NSBlocks.m.obj CMakeFiles/objc.dir/Protocol2.m.obj CMakeFiles/objc.dir/associate.m.obj CMakeFiles/objc.dir/blocks_runtime.m.obj CMakeFiles/objc.dir/properties.m.obj CMakeFiles/objc.dir/gc_none.c.obj CMakeFiles/objc.dir/arc.mm.obj CMakeFiles/objc.dir/objcxx_eh.cc.obj  -Wl,-Bstatic  -lc++abi  -Wl,-Bdynamic  C:/msys64/usr/lib/libm.a  -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 && cd ."
lld-link: error: undefined symbol: operator delete(void*)
>>> referenced by CMakeFiles/objc.dir/arc.mm.obj:(objc_storeWeak)
>>> referenced by CMakeFiles/objc.dir/arc.mm.obj:(incrementWeakRefCount(objc_object*))
>>> referenced by CMakeFiles/objc.dir/arc.mm.obj:(objc_loadWeakRetained)
>>> referenced 96 more times

lld-link: error: undefined symbol: operator new(unsigned long long)
>>> referenced by CMakeFiles/objc.dir/arc.mm.obj:(incrementWeakRefCount(objc_object*))

lld-link: error: undefined symbol: std::__1::__libcpp_execute_once(void**, void (*)())
>>> referenced by libc++abi.a(cxa_exception_storage.cpp.obj):(__cxa_get_globals)
>>> referenced by libc++abi.a(cxa_exception_storage.cpp.obj):(__cxa_get_globals_fast)

lld-link: error: undefined symbol: std::__1::__libcpp_tls_get(long)
>>> referenced by libc++abi.a(cxa_exception_storage.cpp.obj):(__cxa_get_globals)
>>> referenced by libc++abi.a(cxa_exception_storage.cpp.obj):(__cxa_get_globals_fast)

lld-link: error: undefined symbol: std::__1::__libcpp_tls_set(long, void*)
>>> referenced by libc++abi.a(cxa_exception_storage.cpp.obj):(__cxa_get_globals)
>>> referenced by libc++abi.a(cxa_exception_storage.cpp.obj):(__cxxabiv1::(anonymous namespace)::destruct_(void*))

lld-link: error: undefined symbol: std::__1::__libcpp_tls_create(long*, void (*)(void*))
>>> referenced by libc++abi.a(cxa_exception_storage.cpp.obj):(__cxxabiv1::(anonymous namespace)::construct_())

lld-link: error: undefined symbol: std::__1::__libcpp_mutex_lock(void**)
>>> referenced by libc++abi.a(cxa_guard.cpp.obj):(__cxa_guard_acquire)
>>> referenced by libc++abi.a(cxa_guard.cpp.obj):(__cxa_guard_release)
>>> referenced by libc++abi.a(cxa_guard.cpp.obj):(__cxa_guard_abort)
>>> referenced 4 more times

lld-link: error: undefined symbol: std::__1::__libcpp_condvar_wait(void**, void**)
>>> referenced by libc++abi.a(cxa_guard.cpp.obj):(__cxa_guard_acquire)

lld-link: error: undefined symbol: std::__1::__libcpp_mutex_unlock(void**)
>>> referenced by libc++abi.a(cxa_guard.cpp.obj):(__cxa_guard_acquire)
>>> referenced by libc++abi.a(cxa_guard.cpp.obj):(__cxa_guard_acquire)
>>> referenced by libc++abi.a(cxa_guard.cpp.obj):(__cxa_guard_release)
>>> referenced 5 more times

lld-link: error: undefined symbol: std::__1::__libcpp_condvar_broadcast(void**)
>>> referenced by libc++abi.a(cxa_guard.cpp.obj):(__cxa_guard_release)
>>> referenced by libc++abi.a(cxa_guard.cpp.obj):(__cxa_guard_abort)
```

I’d very much appreciate your further input @davidchisnall.