### PR TITLE
Updated the class_copyMethodList

### DIFF
--- a/runtime.c
+++ b/runtime.c
@@ -208,6 +208,11 @@ BOOL class_addProtocol(Class cls, Protocol *protocol)
 
 Ivar * class_copyIvarList(Class cls, unsigned int *outCount)
 {
+    if (outCount != NULL)
+    {
+        *outCount = 0x0;
+    }
+
 	CHECK_ARG(cls);
 	struct objc_ivar_list *ivarlist = NULL;
 	unsigned int count = 0;
@@ -244,13 +249,13 @@ Ivar * class_copyIvarList(Class cls, unsigned int *outCount)
 
 Method * class_copyMethodList(Class cls, unsigned int *outCount)
 {
-        if (outCount != NULL)
-                *outCount = 0x0;
+    if (outCount != NULL)
+    {
+        *outCount = 0x0;
+    }
 
 	CHECK_ARG(cls);
-
 	unsigned int count = 0;
-
 	Method *list;
 	struct objc_method_list *methods;
 
@@ -289,6 +294,11 @@ Method * class_copyMethodList(Class cls, unsigned int *outCount)
 
 Protocol*__unsafe_unretained* class_copyProtocolList(Class cls, unsigned int *outCount)
 {
+    if (outCount != NULL)
+    {
+        *outCount = 0x0;
+    }
+
 	CHECK_ARG(cls);
 	struct objc_protocol_list *protocolList = NULL;
 	struct objc_protocol_list *list;

--- a/runtime.c
+++ b/runtime.c
@@ -244,8 +244,13 @@ Ivar * class_copyIvarList(Class cls, unsigned int *outCount)
 
 Method * class_copyMethodList(Class cls, unsigned int *outCount)
 {
+        if (outCount != NULL)
+                *outCount = 0x0;
+
 	CHECK_ARG(cls);
+
 	unsigned int count = 0;
+
 	Method *list;
 	struct objc_method_list *methods;
 
@@ -256,10 +261,12 @@ Method * class_copyMethodList(Class cls, unsigned int *outCount)
 			count += methods->count;
 		}
 	}
+
 	if (outCount != NULL)
 	{
 		*outCount = count;
 	}
+
 	if (count == 0)
 	{
 		return NULL;


### PR DESCRIPTION
Updated the class_copyMethodList to clear the stack garbage for outCount if preset before checking the class is null.  This allows the pyobjc to mostly work. 