### PR TITLE
Update runtime defines to match Apple platforms

### DIFF
--- a/objc/runtime.h
+++ b/objc/runtime.h
@@ -190,30 +190,32 @@ typedef struct
 
 
 #ifndef YES
-#	define YES ((BOOL)1)
+#	if __has_feature(objc_bool)
+#		define YES __objc_yes
+#	else
+#		define YES ((BOOL)1)
+#	endif
 #endif
 #ifndef NO
-#	define NO ((BOOL)0)
+#	if __has_feature(objc_bool)
+#		define NO __objc_no
+#	else
+#		define NO ((BOOL)0)
+#	endif
 #endif
 
-#ifdef __GNUC
-#	define _OBJC_NULL_PTR __null
-#elif defined(__cplusplus)
-#	if __has_feature(cxx_nullptr)
-#		define _OBJC_NULL_PTR nullptr
-#	else
-#		define _OBJC_NULL_PTR 0
-#	endif
+#if __has_feature(cxx_nullptr)
+#	define _OBJC_NULL_PTR nullptr
 #else
-#	define _OBJC_NULL_PTR ((void*)0)
+#	define _OBJC_NULL_PTR NULL
 #endif
 
 #ifndef nil
-#	define nil ((id)_OBJC_NULL_PTR)
+#	define nil _OBJC_NULL_PTR
 #endif
 
 #ifndef Nil
-#	define Nil ((Class)_OBJC_NULL_PTR)
+#	define Nil _OBJC_NULL_PTR
 #endif
 
 #include "slot.h"


### PR DESCRIPTION
This updates the defines for `YES`, `NO`, `nil`, and `Nil` to match Apple platforms:

- Use `objc_bool` language keywords for `YES` and `NO` if available:
  > Previously, the `BOOL` type was simply a typedef for `signed char`, and `YES` and `NO` were macros that expand to `(BOOL)1` and `(BOOL)0` respectively. To support `@YES` and `@NO` expressions, these macros are now defined using new language keywords in `<objc/objc.h>`:
  > ...
  > The compiler implicitly converts `__objc_yes` and `__objc_no` to `(BOOL)1` and `(BOOL)0`. The keywords are used to disambiguate BOOL and integer literals.  
  https://releases.llvm.org/3.1/tools/clang/docs/ObjectiveCLiterals.html

  In our experience using `@YES` and `@NO` works fine without this change, but maybe there are other benefits and it seems more correct to use these keywords when available.

- Define `nil` and `Nil` as `NULL`/`nullptr` without casting to `id`/`Class`.  

  While these casts are certainly correct, they result in warnings like the following when using `nil` instead of `NULL` for by-reference variables (like for a returned NSError):  
  > warning: incompatible pointer types sending 'id' to parameter of type 'NSError *__autoreleasing *' [-Wincompatible-pointer-types]

   While using `NULL` would be more correct here, we found that a lot of code uses `nil` parameters for these kinds of APIs, which in our case results in a lot of warning-noise in 3rd party code we are using, and because these warnings don’t appear on Apple platforms authors can be [hesitant to fix these](https://github.com/ZipArchive/ZipArchive/pull/573).

Apple’s implementation is e.g. available here for reference (`__DARWIN_NULL` is defined as `NULL`):
https://opensource.apple.com/source/objc4/objc4-818.2/runtime/objc.h.auto.html