### PR TITLE
Fix autorelease pool emptying when new references are added

### DIFF
--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TESTS
 	Category.m
 	ExceptionTest.m
 	FastARC.m
+	FastARCPool.m
 	FastRefCount.m
 	Forward.m
 	ManyManySelectors.m

--- a/Test/FastARCPool.m
+++ b/Test/FastARCPool.m
@@ -1,0 +1,41 @@
+#include "Test.h"
+
+#define POOL_SIZE (4096 / sizeof(void*))
+
+static BOOL called;
+
+@interface Canary : Test
+@end
+@implementation Canary
+- (void)dealloc
+{
+	called = YES;
+	[super dealloc];
+}
+@end
+
+@interface Creator : Test
+@end
+@implementation Creator
+- (void)dealloc
+{
+	// Add a new page of autorelease references to see if we can still release
+	// the reference on the canary object.
+	for (int i = 0; i < POOL_SIZE; i++)
+		[[Test new] autorelease];
+	[super dealloc];
+}
+@end
+
+int main()
+{
+	called = NO;
+	@autoreleasepool
+	{
+		[[Canary new] autorelease];
+		[[Creator new] autorelease];
+	}
+	assert(called == YES);
+
+	return 0;
+}

--- a/arc.mm
+++ b/arc.mm
@@ -169,28 +169,28 @@ static void emptyPool(struct arc_tls *tls, void *stop)
 			stopPool = stopPool->previous;
 		}
 	}
-	while (tls->pool != stopPool)
-	{
-		while (tls->pool->insert > tls->pool->pool)
+	do {
+		while (tls->pool != stopPool)
 		{
-			tls->pool->insert--;
-			// This may autorelease some other objects, so we have to work in
-			// the case where the autorelease pool is extended during a -release.
-			release(*tls->pool->insert);
+			while (tls->pool->insert > tls->pool->pool)
+			{
+				tls->pool->insert--;
+				// This may autorelease some other objects, so we have to work in
+				// the case where the autorelease pool is extended during a -release.
+				release(*tls->pool->insert);
+			}
+			void *old = tls->pool;
+			tls->pool = tls->pool->previous;
+			free(old);
 		}
-		void *old = tls->pool;
-		tls->pool = tls->pool->previous;
-		free(old);
-	}
-	if (NULL != tls->pool)
-	{
+		if (NULL == tls->pool) break;
 		while ((stop == NULL || (tls->pool->insert > stop)) &&
 		       (tls->pool->insert > tls->pool->pool))
 		{
 			tls->pool->insert--;
 			release(*tls->pool->insert);
 		}
-	}
+	} while (tls->pool != stopPool);
 	//fprintf(stderr, "New insert: %p.  Stop: %p\n", tls->pool->insert, stop);
 }
 


### PR DESCRIPTION
An edge case exists where it is possible to leak references whilst emptying the arc autorelease pool for a thread when more object references are added to it (via a dealloc or release method) whilst releasing a reference in the pool. The existing code attempts to cover this scenario but if the reference is located in the same `struct arc_autorelease_pool` page as the `stop` address and enough references are added to cause one or more pages to be appended, it will prematurely stop inside of or at the beginning of the last appended page.

If the thread has further pools to pop and the scenario does not occur again when they are emptied, the missed references will then be released as normal. ~~However, if the pool being emptied was the root autorelease pool of the thread (i.e. `stop` is `NULL` and was happening as part of `cleanupPools()`), the pages before the last appended page and the references in them will leak.~~

This PR changes the logic slightly to check that the page is still the same as the `stopPool`.

Fixes #217 

One complication of this PR which could also occur in the existing code is that if the objects are written to always generate another autoreleased reference when released, the loop will never exit as there will always be more references to release.