### PR TITLE
Workaround bug in test ObjCXXEHInterop_arc

### DIFF
--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -35,7 +35,6 @@ set(TESTS
 	PropertyAttributeTest.m
 	ProtocolExtendedProperties.m
 	PropertyIntrospectionTest.m
-	PropertyIntrospectionTest2_arc.m
 	ProtocolCreation.m
 	ResurrectInDealloc_arc.m
 	RuntimeTest.m

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -44,7 +44,6 @@ set(TESTS
 	WeakReferences_arc.m
 	WeakImportClass.m
 	ivar_arc.m
-	ivar_atomic.m
 	IVarOverlap.m
 	IVarSuperclassOverlap.m
 	objc_msgSend.m

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -144,12 +144,15 @@ addtest_variants("ForwardDeclareProtocolAccess" "ForwardDeclareProtocolAccess.m;
 if (ENABLE_OBJCXX)
 	addtest_variants(ObjCXXEHInterop "ObjCXXEHInterop.mm;ObjCXXEHInterop.m" true)
 	addtest_variants(ObjCXXEHInteropTwice "ObjCXXEHInteropTwice.mm" true)
-	# This test is failing on Win32, but not for any obvious reason.  Disable
-	# it for now to keep CI happy.
-	if (WIN32)
-	else()
-		addtest_variants(ObjCXXEHInterop_arc "ObjCXXEHInterop_arc.mm;ObjCXXEHInterop_arc.m" true)
-	endif()
+	addtest_variants(ObjCXXEHInterop_arc "ObjCXXEHInterop_arc.mm;ObjCXXEHInterop_arc.m" true)
+	# Disable the cleanup step in LLVM's CodeGen pass `WinEHPrepare` in order to
+	# workaround a bug in Clang: With ARC enabled, it accidentially truncates
+	# catch handlers by replacing calls to the objc_retain() runtime function
+	# with UnreachableInst. This is because llvm.objc_* intrinsics are lowered
+	# in an earlier pass (Pre-ISel Intrinsic Lowering) and thus `WinEHPrepare`
+	# sees them as regular functions and won't (always) reserve them.
+	target_compile_options(ObjCXXEHInterop_arc PRIVATE -mllvm --disable-cleanups)
+	target_compile_options(ObjCXXEHInterop_arc_optimised PRIVATE -mllvm --disable-cleanups)
 endif()
 
 # Some tests use enough memory that they fail on CI intermittently if they


### PR DESCRIPTION
The test failure appears to origin from a Clang bug that is related to the CodeGen passes [PreISelIntrinsicLowering](https://github.com/llvm/llvm-project/blob/38e802a09de645b54c3fc983d692a1436bfc7d13/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp#L70) and [WinEHPrepare](https://github.com/llvm/llvm-project/blob/88bc24a7e39ef3f85857c3d0857e0e5c93b50bbc/llvm/lib/CodeGen/WinEHPrepare.cpp#L972). In simple cases like this test, the workaround is effective. In complex cases it can cause a crash in Clang further down the line. Would it make sense to pull it into upstream libobjc2 until we have a fix in mainline Clang and a release that contains it?

The --disable-cleanups flag used here is not as general-purpose as it may sound. It's used in `WinEHPrepare.cpp` exclusively and only triggers a single branch.

Happy to talk about an actual fix in more detail when time permits!