### PR TITLE
Enable test ObjCXXEHInterop_arc on Windows for Clang 16+

### DIFF
--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -144,9 +144,10 @@ addtest_variants("ForwardDeclareProtocolAccess" "ForwardDeclareProtocolAccess.m;
 if (ENABLE_OBJCXX)
 	addtest_variants(ObjCXXEHInterop "ObjCXXEHInterop.mm;ObjCXXEHInterop.m" true)
 	addtest_variants(ObjCXXEHInteropTwice "ObjCXXEHInteropTwice.mm" true)
-	# This test is failing on Win32, but not for any obvious reason.  Disable
-	# it for now to keep CI happy.
-	if (WIN32)
+	if (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+		if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0.0)
+			addtest_variants(ObjCXXEHInterop_arc "ObjCXXEHInterop_arc.mm;ObjCXXEHInterop_arc.m" true)
+		endif()
 	else()
 		addtest_variants(ObjCXXEHInterop_arc "ObjCXXEHInterop_arc.mm;ObjCXXEHInterop_arc.m" true)
 	endif()

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -18,7 +18,6 @@ set(TESTS
 	alias.m
 	alignTest.m
 	AllocatePair.m
-	ARCTest_arc.m
 	AssociatedObject.m
 	AssociatedObject2.m
 	BlockImpTest.m
@@ -35,7 +34,6 @@ set(TESTS
 	PropertyAttributeTest.m
 	ProtocolExtendedProperties.m
 	PropertyIntrospectionTest.m
-	PropertyIntrospectionTest2_arc.m
 	ProtocolCreation.m
 	ResurrectInDealloc_arc.m
 	RuntimeTest.m
@@ -59,7 +57,16 @@ set(TESTS
 	setSuperclass.m
 )
 
+set(ENABLE_ALL_OBJC_ARC_TESTS On)
+
 if (WIN32)
+	# On Windows these tests work only with more recent versions of Clang
+	set(ENABLE_ALL_OBJC_ARC_TESTS Off)
+	if (CMAKE_C_COMPILER_ID STREQUAL Clang)
+		if (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0.0)
+			set(ENABLE_ALL_OBJC_ARC_TESTS On)
+		endif()
+	endif()
 else ()
 	# Don't run the tests that are specific to Itanium-style exceptions on
 	# Windows.
@@ -68,6 +75,13 @@ else ()
 	ForeignException.m
 	)
 endif ()
+
+if (ENABLE_ALL_OBJC_ARC_TESTS)
+	list(APPEND TESTS
+	ARCTest_arc.m
+	PropertyIntrospectionTest2_arc.m
+	)
+endif()
 
 # List of single-file tests that won't work with the legacy ABI and so
 # shouldn't be run in legacy mode.


### PR DESCRIPTION
This test used to fail on Windows, because Clang's codegen and transformation haven't been in-line with the requirements of the WinEH backend in LLVM. The following changes implement the missing pieces and let the test to pass in both debug and release mode:

https://reviews.llvm.org/D128190 [WinEH] Apply funclet operand bundles to nounwind intrinsics that lower to function calls in the course of IR transforms
https://reviews.llvm.org/D134441 [ObjC][ARC] Fix target register for call expanded from CALL_RVMARKER on Windows 
https://reviews.llvm.org/D137939 [CGObjC] Open cleanup scope before SaveAndRestore CurrentFuncletPad and push CatchRetScope early
https://reviews.llvm.org/D137944 [ObjC][ARC] Teach the OptimizeSequences step of ObjCARCOpts about WinEH funclet tokens