### PR TITLE
Fix lock-ordering during init

### DIFF
--- a/dtable.c
+++ b/dtable.c
@@ -683,6 +683,13 @@ PRIVATE void objc_send_initialize(id object)
 		objc_send_initialize((id)class->super_class);
 	}
 
+	// Lock the runtime while we're creating dtables and before we acquire the
+	// init lock.  This prevents a lock-order reversal when dtable_for_class is
+	// called from something holding the runtime lock while we're still holding
+	// the initialize lock.  We should ensure that we never acquire the runtime
+	// lock after acquiring the initialize lock.
+	LOCK_RUNTIME();
+
 	// Superclass +initialize might possibly send a message to this class, in
 	// which case this method would be called again.  See NSObject and
 	// NSAutoreleasePool +initialize interaction in GNUstep.
@@ -690,7 +697,10 @@ PRIVATE void objc_send_initialize(id object)
 	{
 		// We know that initialization has started because the flag is set.
 		// Check that it's finished by grabbing the class lock.  This will be
-		// released once the class has been fully initialized.
+		// released once the class has been fully initialized. The runtime
+		// lock needs to be released first to prevent a deadlock between the
+		// runtime lock and the class-specific lock.
+		UNLOCK_RUNTIME();
 
 		objc_sync_enter((id)meta);
 		objc_sync_exit((id)meta);
@@ -704,15 +714,10 @@ PRIVATE void objc_send_initialize(id object)
 	// When this happens there is a small chance we could hit the same spinlock
 	// and deadlock the process (as any further attempts to acquire the runtime 
 	// will also block forever).
+	UNLOCK_RUNTIME();
+
 	LOCK_OBJECT_FOR_SCOPE((id)meta);
-
-	// Lock the runtime while we're creating dtables and before we acquire the
-	// init lock.  This prevents a lock-order reversal when dtable_for_class is
-	// called from something holding the runtime lock while we're still holding
-	// the initialize lock.  We should ensure that we never acquire the runtime
-	// lock after acquiring the initialize lock.
 	LOCK_RUNTIME();
-
 	LOCK(&initialize_lock);
 	if (objc_test_class_flag(class, objc_class_flag_initialized))
 	{

--- a/dtable.c
+++ b/dtable.c
@@ -683,13 +683,6 @@ PRIVATE void objc_send_initialize(id object)
 		objc_send_initialize((id)class->super_class);
 	}
 
-	// Lock the runtime while we're creating dtables and before we acquire any
-	// other locks.  This prevents a lock-order reversal when
-	// dtable_for_class is called from something holding the runtime lock while
-	// we're still holding the initialize lock.  We should ensure that we never
-	// acquire the runtime lock after acquiring the initialize lock.
-	LOCK_RUNTIME();
-
 	// Superclass +initialize might possibly send a message to this class, in
 	// which case this method would be called again.  See NSObject and
 	// NSAutoreleasePool +initialize interaction in GNUstep.
@@ -697,10 +690,7 @@ PRIVATE void objc_send_initialize(id object)
 	{
 		// We know that initialization has started because the flag is set.
 		// Check that it's finished by grabbing the class lock.  This will be
-		// released once the class has been fully initialized. The runtime
-		// lock needs to be released first to prevent a deadlock between the
-		// runtime lock and the class-specific lock.
-		UNLOCK_RUNTIME();
+		// released once the class has been fully initialized.
 
 		objc_sync_enter((id)meta);
 		objc_sync_exit((id)meta);
@@ -708,7 +698,21 @@ PRIVATE void objc_send_initialize(id object)
 		return;
 	}
 
+	// We should try to acquire the class lock before any runtime/init locks.
+	// If another thread is in the middle of running `allocateHiddenClass()` it 
+	// has acquired a spinlock and will be trying to acquire the runtime lock. 
+	// When this happens there is a small chance we could hit the same spinlock
+	// and deadlock the process (as any further attempts to acquire the runtime 
+	// will also block forever).
 	LOCK_OBJECT_FOR_SCOPE((id)meta);
+
+	// Lock the runtime while we're creating dtables and before we acquire the
+	// init lock.  This prevents a lock-order reversal when dtable_for_class is
+	// called from something holding the runtime lock while we're still holding
+	// the initialize lock.  We should ensure that we never acquire the runtime
+	// lock after acquiring the initialize lock.
+	LOCK_RUNTIME();
+
 	LOCK(&initialize_lock);
 	if (objc_test_class_flag(class, objc_class_flag_initialized))
 	{


### PR DESCRIPTION
Reorders how locking is handled in `objc_send_initialize()` to prevent a deadlock. Previously, contention on the low level spinlocks could cause a very intermittent deadlock:
  - Thread A : `objc_send_initialize()` holds the runtime lock, then tries to acquire the object lock on the metaclass, which needs to initialize the mutex for the new metaclass inside `referenceListForObject()`, so it tries to lock the `lock_for_pointer()` / `lock_spinlock()`
  - Thread B : `referenceListForObject()` holds a spinlock for an unrelated object while running `initHiddenClassForObject()` -> `allocateHiddenClass()`, which tries to acquire the runtime lock 
  
  If the metaclass object pointer in Thread A hashes to the same spinlock as the object in thread B, the runtime lock ends up deadlocked forever.
  
  Potential fix for [this issue](https://github.com/gnustep/libobjc2/issues/236)