### PR TITLE
Prefer system-provided robin-map

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,6 @@ jobs:
     name: ${{ matrix.os }} ${{ matrix.build-type }} LLVM-${{ matrix.llvm-version }} ${{ matrix.cxxlib }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - name: Install dependencies 
         run: |
           sudo apt install ninja-build
@@ -92,8 +90,6 @@ jobs:
     name: Cross-build for ${{ matrix.arch.triple }} LLVM-${{ matrix.llvm-version}} ${{ matrix.build-type }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - name: Install cross-compile toolchain and QEMU
         run: |
           sudo apt update

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third_party/robin-map"]
-	path = third_party/robin-map
-	url = https://github.com/Tessil/robin-map

--- a/ANNOUNCE
+++ b/ANNOUNCE
@@ -37,16 +37,6 @@ Alternatively, a tarball is available from:
 https://github.com/gnustep/libobjc2/archive/v2.2.zip
 https://github.com/gnustep/libobjc2/archive/v2.2.tar.gz
 
-The submodule is available from:
-
-https://github.com/Tessil/robin-map/archive/d37a410.zip
-https://github.com/Tessil/robin-map/archive/d37a410.tar.gz
-
-This will extract as robin-map-d37a41003bfbc7e12e34601f93c18ca2ff6d7c07.
-You must move the contents of that directory into third_party/robin_map in the
-libobjc2 tree.
-
-
 The runtime library is responsible for implementing the core features of the
 object model, as well as exposing introspection features to the user.  The
 GNUstep runtime implements a superset of Apple's Objective-C Runtime APIs.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,18 +122,13 @@ endif (WIN32)
 
 find_package(tsl-robin-map)
 
-if (tsl-robin-map_FOUND)
-	include_directories("${tsl-robin-map_INCLUDE_DIRS}")
-else ()
-	if (NOT EXISTS "${CMAKE_SOURCE_DIR}/third_party/robin-map/include/tsl/robin_map.h")
-		message(FATAL_ERROR "Git submodules not present, please run:\n\n"
-							" $ git submodule init && git submodule update\n\n"
-							"If you did not checkout via git, you will need to"
-							"fetch the submodule's contents from"
-							"https://github.com/Tessil/robin-map/")
-	endif ()
+if (NOT tls-robin-map_FOUND)
+	FetchContent_Declare(
+		robinmap
+		GIT_REPOSITORY https://github.com/Tessil/robin-map/
+		GIT_TAG        7d37a41003bfbc7e12e34601f93c18ca2ff6d7c07)
 
-	include_directories("${CMAKE_SOURCE_DIR}/third_party/robin-map/include/")
+	FetchContent_MakeAvailable(robinmap)
 endif()
 
 if (WIN32)
@@ -242,6 +237,7 @@ if (WIN32)
 	target_link_libraries(objc ntdll.dll)
 endif()
 
+target_link_libraries(objc tsl::robin_map)
 
 set_target_properties(objc PROPERTIES
 	LINKER_LANGUAGE C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,14 +120,19 @@ else ()
 	list(APPEND libobjc_C_SRCS eh_personality.c)
 endif (WIN32)
 
-if (NOT EXISTS "${CMAKE_SOURCE_DIR}/third_party/robin-map/include/tsl/robin_map.h")
-	message(FATAL_ERROR "Git submodules not present, please run:\n\n"
-						" $ git submodule init && git submodule update\n\n"
-						"If you did not checkout via git, you will need to"
-						"fetch the submodule's contents from"
-						"https://github.com/Tessil/robin-map/")
-endif ()
+find_path(ROBIN_MAP_HEADER NAMES "tsl/robin_map.h")
 
+if (NOT ROBIN_MAP_HEADER)
+	if (NOT EXISTS "${CMAKE_SOURCE_DIR}/third_party/robin-map/include/tsl/robin_map.h")
+		message(FATAL_ERROR "Git submodules not present, please run:\n\n"
+							" $ git submodule init && git submodule update\n\n"
+							"If you did not checkout via git, you will need to"
+							"fetch the submodule's contents from"
+							"https://github.com/Tessil/robin-map/")
+	endif ()
+
+	include_directories("${CMAKE_SOURCE_DIR}/third_party/robin-map/include/")
+endif()
 
 if (WIN32)
 	set(OLD_ABI_COMPAT_DEFAULT false)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 enable_language(OBJC OBJCXX)
 
 INCLUDE (CheckCXXSourceCompiles)
+INCLUDE (FetchContent)
 
 set(libobjc_VERSION 4.6)
 
@@ -126,7 +127,7 @@ if (NOT tls-robin-map_FOUND)
 	FetchContent_Declare(
 		robinmap
 		GIT_REPOSITORY https://github.com/Tessil/robin-map/
-		GIT_TAG        7d37a41003bfbc7e12e34601f93c18ca2ff6d7c07)
+		GIT_TAG        v1.2.1)
 
 	FetchContent_MakeAvailable(robinmap)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,9 +120,11 @@ else ()
 	list(APPEND libobjc_C_SRCS eh_personality.c)
 endif (WIN32)
 
-find_path(ROBIN_MAP_HEADER NAMES "tsl/robin_map.h")
+find_package(tsl-robin-map)
 
-if (NOT ROBIN_MAP_HEADER)
+if (tsl-robin-map_FOUND)
+	include_directories("${tsl-robin-map_INCLUDE_DIRS}")
+else ()
 	if (NOT EXISTS "${CMAKE_SOURCE_DIR}/third_party/robin-map/include/tsl/robin_map.h")
 		message(FATAL_ERROR "Git submodules not present, please run:\n\n"
 							" $ git submodule init && git submodule update\n\n"

--- a/INSTALL
+++ b/INSTALL
@@ -14,15 +14,6 @@ things that can be used by other programs that actually perform the building.
 I recommend that you use Ninja for building if you are compiling regularly, but
 these instructions will use Make to avoid the need for an extra dependency.
 
-When checking out the code make sure you check out git submodules as well
-either by using
-
-	$ git checkout --recursive <URL>
-	
-or by getting submodules after checkout using
-
-	$ git submodule update --init
-
 After checking out the code, build as follows:
 
 	$ mkdir Build

--- a/arc.mm
+++ b/arc.mm
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <vector>
-#include "third_party/robin-map/include/tsl/robin_map.h"
+#include <tsl/robin_map.h>
 #import "lock.h"
 #import "objc/runtime.h"
 #import "objc/blocks_runtime.h"

--- a/selector_table.cc
+++ b/selector_table.cc
@@ -11,7 +11,7 @@
 #include <vector>
 #include <mutex>
 #include <forward_list>
-#include "third_party/robin-map/include/tsl/robin_set.h"
+#include "tsl/robin_set.h"
 #include "class.h"
 #include "lock.h"
 #include "method.h"

--- a/selector_table.cc
+++ b/selector_table.cc
@@ -11,7 +11,7 @@
 #include <vector>
 #include <mutex>
 #include <forward_list>
-#include "tsl/robin_set.h"
+#include <tsl/robin_set.h>
 #include "class.h"
 #include "lock.h"
 #include "method.h"


### PR DESCRIPTION
[A lot of distributions ship with robin-map in their package management system](https://repology.org/project/robin-map/versions), so it may not be a hard requirement to have robin-map as a submodule.

This PR updates the build system to search for `tsl/robin_map.h` and use that one if available; if not, fall back to the submodule.