### PR TITLE
Initial Windows on ARM (AArch64) Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,7 +353,12 @@ endif()
 # threading implementation (we do for everything except thread-local storage)
 set(CMAKE_THREAD_PREFER_PTHREAD)
 include(FindThreads)
+# Link against ntdll.dll for RtlRaiseException
+if (WIN32)
+target_link_libraries(objc Threads::Threads ntdll.dll)
+else()
 target_link_libraries(objc Threads::Threads)
+endif()
 
 
 

--- a/block_to_imp.c
+++ b/block_to_imp.c
@@ -177,7 +177,12 @@ static struct trampoline_set *alloc_trampolines(char *start, char *end)
 	}
 	metadata->buffers->headers[HEADERS_PER_PAGE-1].block = NULL;
 	mprotect(metadata->buffers->rx_buffer, PAGE_SIZE, PROT_READ | PROT_EXEC);
+#if defined(_WIN32) && (defined(__arm__) || defined(__aarch64__))
+  FlushInstructionCache(GetCurrentProcess(), start, end - start);
+#else
 	clear_cache(metadata->buffers->rx_buffer, &metadata->buffers->rx_buffer[PAGE_SIZE]);
+#endif
+
 	return metadata;
 }
 

--- a/objc_msgSend.aarch64.S
+++ b/objc_msgSend.aarch64.S
@@ -1,5 +1,16 @@
 #define ARGUMENT_SPILL_SIZE (8*10 + 8*16)
-.macro MSGSEND receiver, sel
+
+#ifdef _WIN64
+#	define START_PROC(x) .seh_proc x
+#	define END_PROC(x) .seh_endproc
+#	define FRAME_OFFSET(x) .seh_stackalloc x
+#else
+#	define START_PROC(x) .cfi_startproc
+#	define END_PROC(x) .cfi_endproc
+#	define FRAME_OFFSET(x) .cfi_adjust_cfa_offset x
+#endif
+
+.macro MSGSEND fnname, receiver, sel
 	.cfi_startproc
 	cbz    \receiver, 4f                   // Skip everything if the receiver is nil
 	                                       // Jump to 6: if this is a small object
@@ -7,6 +18,8 @@
 	cbnz   x9, 6f
 
 	ldr    x9, [\receiver]                 // Load class to x9 if not a small int
+
+.align 2
 1:
 	ldr    x9, [x9, #DTABLE_OFFSET]        // Dtable -> x9
 	ldr    w10, [\sel]                     // selector->index -> x10
@@ -35,6 +48,7 @@
 	ldr    x9, [x9, #SLOT_OFFSET]          // Load the method from the slot
 	br     x9                              // Tail-call the method
 
+.align 2
 4:	                                       // Nil receiver
 	mov    x0, #0
 	mov    v0.d[0], x0
@@ -79,21 +93,45 @@
 	ldp    \receiver, x8, [sp], #(ARGUMENT_SPILL_SIZE + 16)
 	br     x9
 6:
+#if __ELF__
 	adrp   x10, :got:SmallObjectClasses
 	ldr    x10, [x10, :got_lo12:SmallObjectClasses]
 	ldr    x9, [x10, x9, lsl #3]
+#else
+  adr    x9, CDECL(SmallObjectClasses)
+#endif
 	b      1b
 	.cfi_endproc
 .endm
 
+#ifdef _WIN64
+.text
+.def objc_msgSend;
+.scl 2;
+.type 32;
+.endef
+.def objc_msgSend_fpret;
+.scl 2;
+.type 32;
+.endef
+.def objc_msgSend_stret;
+.scl 2;
+.type 32;
+.endef
+#endif
 .globl CDECL(objc_msgSend_fpret)
 TYPE_DIRECTIVE(CDECL(objc_msgSend_fpret), %function)
 .globl CDECL(objc_msgSend)
 TYPE_DIRECTIVE(CDECL(objc_msgSend), %function)
 .globl CDECL(objc_msgSend_stret)
 TYPE_DIRECTIVE(CDECL(objc_msgSend_stret), %function)
-CDECL(objc_msgSend):
 CDECL(objc_msgSend_fpret):
 CDECL(objc_msgSend_stret):
-	MSGSEND x0, x1
-
+CDECL(objc_msgSend):
+	MSGSEND objc_msgSend x0, x1
+#ifdef _WIN64
+.section        .drectve,"yn"
+.ascii  " /EXPORT:objc_msgSend"
+.ascii  " /EXPORT:objc_msgSend_fpret"
+.ascii  " /EXPORT:objc_msgSend_stret"
+#endif

--- a/objc_msgSend.aarch64.S
+++ b/objc_msgSend.aarch64.S
@@ -61,6 +61,8 @@
 										  // that we adjust the sp before storing the pair
 										  // of registers.
 	stp    x0, x1, [sp, #-(ARGUMENT_SPILL_SIZE)]!
+	.seh_stackalloc (ARGUMENT_SPILL_SIZE)
+
 	stp    x2, x3, [sp, #16]              // The order is arbitrary, except that
 	stp    x4, x5, [sp, #32]              // fp and lr must be spilled together and
 	stp    x6, x7, [sp, #48]              // it's convenient if \receiver is spilled at sp
@@ -69,13 +71,19 @@
 	stp    q4, q5, [sp, #128]
 	stp    q6, q7, [sp, #160]
 	stp    fp, lr, [sp, #192]
+	.seh_save_fplr	192
+
 	add    fp, sp, 192					  // Adjust frame pointer
+	.seh_add_fp	192
 	stp    \receiver, x8, [sp, #-16]!     // Pre-index by sp-16
+	.seh_stackalloc 16
 
 	// FIXME: Conditionally use SEH directives
+	/*
 	.cfi_def_cfa fp, 16
 	.cfi_offset fp, -16
 	.cfi_offset lr, -8
+	*/
 	
 	                                      // We now have all argument registers, the link
 	                                      // register and the receiver spilled on the
@@ -96,7 +104,12 @@
 	ldp    q4, q5, [sp, #144]
 	ldp    q6, q7, [sp, #176]
 	ldp    fp, lr, [sp, #208]
+	.seh_save_fplr 208
+
+										  // Post-increment sp += ARGUMENT_SPILL_SIZE +16
 	ldp    \receiver, x8, [sp], #(ARGUMENT_SPILL_SIZE + 16)
+	.seh_stackalloc  (ARGUMENT_SPILL_SIZE + 16)
+
 	br     x9
 6:
 										  // Load 63:12 of SmallObjectClasses address

--- a/objc_msgSend.aarch64.S
+++ b/objc_msgSend.aarch64.S
@@ -1,18 +1,52 @@
 #define ARGUMENT_SPILL_SIZE (8*10 + 8*16)
 
+/* Windows ARM64 Exception Handling
+ *
+ * Structured Exception Handling (SEH) on Windows ARM64 differs from the x64
+ * implementation. Functions consist of a single prologue and zero or more
+ * epilogues. Instead of using offsets for the .seh* directives to manipulate the
+ * stack frame, each directive corresponds to a single instruction.
+ *
+ * This presents a challenge for our objc_msgSend function, which only modifies
+ * the stack when a slow lookup is needed (see label "5").
+ *
+ * To address this, we move the directive marking the start of a function deep
+ * into the msgSend body to prevent marking every instruction as ".seh_nop."
+ *
+ *   For 64-bit Windows (_WIN64):
+ *  - EH_START(x): Start of function (no effect on Windows)
+ *  - EH_END(x): End of function (no effect on Windows)
+ *  - EH_START_AT_OFFSET(x): Mark Start of function (Delayed)
+ *  - EH_END_AT_OFFSET(x): Mark End of function (Delayed)
+ *  - EH_END_PROLOGUE: End of function prologue
+ *  - EH_START_EPILOGUE: Start of function epilogue
+ *  - EH_END_EPILOGUE: End of function epilogue
+ *  - EH_SAVE_FP_LR(x): Save Frame Pointer and Link Register
+ *  - EH_STACK_ALLOC(x): Stack allocation (inside prologue)
+ *  - EH_ADD_FP(x): Add to Frame Pointer
+ *  - EH_NOP: Mark instruction with no unwinding relevance
+ *
+ * For non-64-bit Windows systems or other platforms, these macros have no effect and can be used without causing issues.
+ */
+
 #ifdef _WIN64
 #   define EH_START(x)
 #   define EH_END(x)
+
 #   define EH_START_AT_OFFSET(x) .seh_proc x
 #   define EH_END_AT_OFFSET(x) .seh_endproc x
+
 #   define EH_END_PROLOGUE .seh_endprologue
 #   define EH_START_EPILOGUE .seh_startepilogue
 #   define EH_END_EPILOGUE .seh_endepilogue
+
 #   define EH_SAVE_FP_LR(x) .seh_save_fplr x
 #   define EH_STACK_ALLOC(x) .seh_stackalloc x
 #   define EH_ADD_FP(x) .seh_add_fp	x
+
 #   define EH_NOP .seh_nop
 #else
+// Marks the real start and end of the function
 #   define EH_START(x) .cfi_startproc
 #   define EH_END(x) .cfi_endproc
 
@@ -83,11 +117,11 @@
 	stp    x0, x1, [sp, #-(ARGUMENT_SPILL_SIZE)]!
 	EH_STACK_ALLOC((ARGUMENT_SPILL_SIZE))
 
-	stp    x2, x3, [sp, #16]              // The order is arbitrary, except that
+	stp    x2, x3, [sp, #16]
+	EH_NOP                                // The following instructions can be ignored by SEH
+	stp    x4, x5, [sp, #32]
 	EH_NOP
-	stp    x4, x5, [sp, #32]              // fp and lr must be spilled together and
-	EH_NOP
-	stp    x6, x7, [sp, #48]              // it's convenient if \receiver is spilled at sp
+	stp    x6, x7, [sp, #48]
 	EH_NOP
 	stp    q0, q1, [sp, #64]
 	EH_NOP
@@ -97,13 +131,13 @@
 	EH_NOP
 	stp    q6, q7, [sp, #160]
 	EH_NOP
-	stp    fp, lr, [sp, #192]
-	EH_SAVE_FP_LR(192)
+	stp    fp, lr, [sp, #192]             // The order is arbitrary, except that
+	EH_SAVE_FP_LR(192)                    // fp and lr must be spilled together
 
 	add    fp, sp, 192					  // Adjust frame pointer
 	EH_ADD_FP(192)
-	stp    \receiver, x8, [sp, #-16]!     // Pre-index by sp-16
-	EH_STACK_ALLOC(16)
+	stp    \receiver, x8, [sp, #-16]!     // it's convenient if \receiver is spilled at sp
+	EH_STACK_ALLOC(16)					  // stp performed pre-indexing by sp-16
 
 	EH_END_PROLOGUE
 
@@ -112,7 +146,6 @@
 	.cfi_offset fp, -16
 	.cfi_offset lr, -8
 	#endif
-	
 	                                      // We now have all argument registers, the link
 	                                      // register and the receiver spilled on the
 	                                      // stack, with sp containing
@@ -120,7 +153,7 @@
 
 	mov    x0, sp                         // &self, _cmd in arguments
 	mov    x1, \sel
-	bl     CDECL(slowMsgLookup)           // This is the only place where the CFI directives
+	bl     CDECL(slowMsgLookup)           // This is the only place where the EH directives
 	                                      // have to be accurate...
 	mov    x9, x0                         // IMP -> x9
 
@@ -149,7 +182,6 @@
 	EH_STACK_ALLOC((ARGUMENT_SPILL_SIZE + 16))
 
 	EH_END_EPILOGUE
-
 	EH_END_AT_OFFSET(\fnname)
 
 	br     x9

--- a/objc_msgSend.aarch64.S
+++ b/objc_msgSend.aarch64.S
@@ -11,7 +11,7 @@
 #endif
 
 .macro MSGSEND fnname, receiver, sel
-	.cfi_startproc
+	START_PROC(\fnname)
 	cbz    \receiver, 4f                   // Skip everything if the receiver is nil
 	                                       // Jump to 6: if this is a small object
 	ubfx    x9, \receiver, #0, #SMALLOBJ_BITS
@@ -56,7 +56,10 @@
 	br     lr
 5:                                        // Slow lookup
 	                                      // Save anything that will be clobbered by
-	                                      // the call
+	                                      // the call.
+										  // Note that we pre-index (see "!"), meaning
+										  // that we adjust the sp before storing the pair
+										  // of registers.
 	stp    x0, x1, [sp, #-(ARGUMENT_SPILL_SIZE)]!
 	stp    x2, x3, [sp, #16]              // The order is arbitrary, except that
 	stp    x4, x5, [sp, #32]              // fp and lr must be spilled together and
@@ -66,11 +69,14 @@
 	stp    q4, q5, [sp, #128]
 	stp    q6, q7, [sp, #160]
 	stp    fp, lr, [sp, #192]
-	add    fp, sp, 192
-	stp    \receiver, x8, [sp, #-16]!
+	add    fp, sp, 192					  // Adjust frame pointer
+	stp    \receiver, x8, [sp, #-16]!     // Pre-index by sp-16
+
+	// FIXME: Conditionally use SEH directives
 	.cfi_def_cfa fp, 16
 	.cfi_offset fp, -16
 	.cfi_offset lr, -8
+	
 	                                      // We now have all argument registers, the link
 	                                      // register and the receiver spilled on the
 	                                      // stack, with sp containing
@@ -93,14 +99,17 @@
 	ldp    \receiver, x8, [sp], #(ARGUMENT_SPILL_SIZE + 16)
 	br     x9
 6:
-	// Load 63:12 of SmallObjectClasses address
-	adrp   x10, CDECL(SmallObjectClasses)
-	// Add lower 12-bits of SmallObjectClasses address to x10
+										  // Load 63:12 of SmallObjectClasses address
+										  // We use the CDECL macro as Windows prefixes
+										  // cdecl conforming symbols with "_".
+	adrp   x10, CDECL(SmallObjectClasses) // The macro handles this transparently.
+
+										  // Add lower 12-bits of SmallObjectClasses address to x10
 	add    x10, x10, :lo12:CDECL(SmallObjectClasses)
 	ldr    x9, [x10, x9, lsl #3]
 
 	b      1b
-	.cfi_endproc
+	END_PROC(\fnname)
 .endm
 
 #ifdef _WIN64

--- a/objc_msgSend.aarch64.S
+++ b/objc_msgSend.aarch64.S
@@ -1,15 +1,36 @@
 #define ARGUMENT_SPILL_SIZE (8*10 + 8*16)
 
 #ifdef _WIN64
-#	define END_PROC(x) .seh_endproc
-#	define FRAME_OFFSET(x) .seh_stackalloc x
+#   define EH_START(x)
+#   define EH_END(x)
+#   define EH_START_AT_OFFSET(x) .seh_proc x
+#   define EH_END_AT_OFFSET(x) .seh_endproc x
+#   define EH_END_PROLOGUE .seh_endprologue
+#   define EH_START_EPILOGUE .seh_startepilogue
+#   define EH_END_EPILOGUE .seh_endepilogue
+#   define EH_SAVE_FP_LR(x) .seh_save_fplr x
+#   define EH_STACK_ALLOC(x) .seh_stackalloc x
+#   define EH_ADD_FP(x) .seh_add_fp	x
+#   define EH_NOP .seh_nop
 #else
-#	define END_PROC(x) .cfi_endproc
-#	define FRAME_OFFSET(x) .cfi_adjust_cfa_offset x
+#   define EH_START(x) .cfi_startproc
+#   define EH_END(x) .cfi_endproc
+
+// The following directives are either not
+// needed or not available with CFI
+#   define EH_START_AT_OFFSET(x)
+#   define EH_END_AT_OFFSET(x)
+#   define EH_END_PROLOGUE
+#   define EH_START_EPILOGUE
+#   define EH_END_EPILOGUE
+#   define EH_SAVE_FP_LR(x)
+#   define EH_STACK_ALLOC(x)
+#   define EH_ADD_FP(x)
+#   define EH_NOP
 #endif
 
 .macro MSGSEND fnname, receiver, sel
-	//.cfi_startproc
+	EH_START(\fnname)
 
 	cbz    \receiver, 4f                   // Skip everything if the receiver is nil
 	                                       // Jump to 6: if this is a small object
@@ -52,7 +73,7 @@
 	mov    v0.d[1], x0
 	br     lr
 5:                                        // Slow lookup
-	.seh_proc \fnname
+	EH_START_AT_OFFSET(\fnname)
 
 	                                      // Save anything that will be clobbered by
 	                                      // the call.
@@ -60,37 +81,37 @@
 										  // that we adjust the sp before storing the pair
 										  // of registers.
 	stp    x0, x1, [sp, #-(ARGUMENT_SPILL_SIZE)]!
-	.seh_stackalloc (ARGUMENT_SPILL_SIZE)
+	EH_STACK_ALLOC((ARGUMENT_SPILL_SIZE))
 
 	stp    x2, x3, [sp, #16]              // The order is arbitrary, except that
-	.seh_nop
+	EH_NOP
 	stp    x4, x5, [sp, #32]              // fp and lr must be spilled together and
-	.seh_nop
+	EH_NOP
 	stp    x6, x7, [sp, #48]              // it's convenient if \receiver is spilled at sp
-	.seh_nop
+	EH_NOP
 	stp    q0, q1, [sp, #64]
-	.seh_nop
+	EH_NOP
 	stp    q2, q3, [sp, #96]
-	.seh_nop
+	EH_NOP
 	stp    q4, q5, [sp, #128]
-	.seh_nop
+	EH_NOP
 	stp    q6, q7, [sp, #160]
-	.seh_nop
+	EH_NOP
 	stp    fp, lr, [sp, #192]
-	.seh_save_fplr	192
+	EH_SAVE_FP_LR(192)
 
 	add    fp, sp, 192					  // Adjust frame pointer
-	.seh_add_fp	192
+	EH_ADD_FP(192)
 	stp    \receiver, x8, [sp, #-16]!     // Pre-index by sp-16
-	.seh_stackalloc 16
+	EH_STACK_ALLOC(16)
 
-	.seh_endprologue
+	EH_END_PROLOGUE
 
-/*
+	#ifndef _WIN64
 	.cfi_def_cfa fp, 16
 	.cfi_offset fp, -16
 	.cfi_offset lr, -8
-*/
+	#endif
 	
 	                                      // We now have all argument registers, the link
 	                                      // register and the receiver spilled on the
@@ -103,32 +124,33 @@
 	                                      // have to be accurate...
 	mov    x9, x0                         // IMP -> x9
 
-	.seh_startepilogue
+	EH_START_EPILOGUE
 	ldp    x0, x1, [sp, #16]              // Reload spilled argument registers
-	.seh_nop
+	EH_NOP
 	ldp    x2, x3, [sp, #32]
-	.seh_nop
+	EH_NOP
 	ldp    x4, x5, [sp, #64]
-	.seh_nop
+	EH_NOP
 	ldp    x6, x7, [sp, #64]
-	.seh_nop
+	EH_NOP
 	ldp    q0, q1, [sp, #80]
-	.seh_nop
+	EH_NOP
 	ldp    q2, q3, [sp, #112]
-	.seh_nop
+	EH_NOP
 	ldp    q4, q5, [sp, #144]
-	.seh_nop
+	EH_NOP
 	ldp    q6, q7, [sp, #176]
-	.seh_nop
+	EH_NOP
 	ldp    fp, lr, [sp, #208]
-	.seh_save_fplr 208
+	EH_SAVE_FP_LR(208)
 
 										  // Post-increment sp += ARGUMENT_SPILL_SIZE +16
 	ldp    \receiver, x8, [sp], #(ARGUMENT_SPILL_SIZE + 16)
-	.seh_stackalloc  (ARGUMENT_SPILL_SIZE + 16)
+	EH_STACK_ALLOC((ARGUMENT_SPILL_SIZE + 16))
 
-	.seh_endepilogue
-	.seh_endproc
+	EH_END_EPILOGUE
+
+	EH_END_AT_OFFSET(\fnname)
 
 	br     x9
 6:
@@ -142,7 +164,7 @@
 	ldr    x9, [x10, x9, lsl #3]
 
 	b      1b
-	//.cfi_endproc
+	EH_END(\fnname)
 .endm
 
 #ifdef _WIN64

--- a/objc_msgSend.aarch64.S
+++ b/objc_msgSend.aarch64.S
@@ -1,17 +1,16 @@
 #define ARGUMENT_SPILL_SIZE (8*10 + 8*16)
 
 #ifdef _WIN64
-#	define START_PROC(x) .seh_proc x
 #	define END_PROC(x) .seh_endproc
 #	define FRAME_OFFSET(x) .seh_stackalloc x
 #else
-#	define START_PROC(x) .cfi_startproc
 #	define END_PROC(x) .cfi_endproc
 #	define FRAME_OFFSET(x) .cfi_adjust_cfa_offset x
 #endif
 
 .macro MSGSEND fnname, receiver, sel
-	START_PROC(\fnname)
+	//.cfi_startproc
+
 	cbz    \receiver, 4f                   // Skip everything if the receiver is nil
 	                                       // Jump to 6: if this is a small object
 	ubfx    x9, \receiver, #0, #SMALLOBJ_BITS
@@ -19,7 +18,6 @@
 
 	ldr    x9, [\receiver]                 // Load class to x9 if not a small int
 
-.align 2
 1:
 	ldr    x9, [x9, #DTABLE_OFFSET]        // Dtable -> x9
 	ldr    w10, [\sel]                     // selector->index -> x10
@@ -48,13 +46,14 @@
 	ldr    x9, [x9, #SLOT_OFFSET]          // Load the method from the slot
 	br     x9                              // Tail-call the method
 
-.align 2
 4:	                                       // Nil receiver
 	mov    x0, #0
 	mov    v0.d[0], x0
 	mov    v0.d[1], x0
 	br     lr
 5:                                        // Slow lookup
+	.seh_proc \fnname
+
 	                                      // Save anything that will be clobbered by
 	                                      // the call.
 										  // Note that we pre-index (see "!"), meaning
@@ -64,12 +63,19 @@
 	.seh_stackalloc (ARGUMENT_SPILL_SIZE)
 
 	stp    x2, x3, [sp, #16]              // The order is arbitrary, except that
+	.seh_nop
 	stp    x4, x5, [sp, #32]              // fp and lr must be spilled together and
+	.seh_nop
 	stp    x6, x7, [sp, #48]              // it's convenient if \receiver is spilled at sp
+	.seh_nop
 	stp    q0, q1, [sp, #64]
+	.seh_nop
 	stp    q2, q3, [sp, #96]
+	.seh_nop
 	stp    q4, q5, [sp, #128]
+	.seh_nop
 	stp    q6, q7, [sp, #160]
+	.seh_nop
 	stp    fp, lr, [sp, #192]
 	.seh_save_fplr	192
 
@@ -78,12 +84,11 @@
 	stp    \receiver, x8, [sp, #-16]!     // Pre-index by sp-16
 	.seh_stackalloc 16
 
-	// FIXME: Conditionally use SEH directives
-	/*
+	.seh_endprologue
+
 	.cfi_def_cfa fp, 16
 	.cfi_offset fp, -16
 	.cfi_offset lr, -8
-	*/
 	
 	                                      // We now have all argument registers, the link
 	                                      // register and the receiver spilled on the
@@ -95,14 +100,24 @@
 	bl     CDECL(slowMsgLookup)           // This is the only place where the CFI directives
 	                                      // have to be accurate...
 	mov    x9, x0                         // IMP -> x9
+
+	.seh_startepilogue
 	ldp    x0, x1, [sp, #16]              // Reload spilled argument registers
+	.seh_nop
 	ldp    x2, x3, [sp, #32]
+	.seh_nop
 	ldp    x4, x5, [sp, #64]
+	.seh_nop
 	ldp    x6, x7, [sp, #64]
+	.seh_nop
 	ldp    q0, q1, [sp, #80]
+	.seh_nop
 	ldp    q2, q3, [sp, #112]
+	.seh_nop
 	ldp    q4, q5, [sp, #144]
+	.seh_nop
 	ldp    q6, q7, [sp, #176]
+	.seh_nop
 	ldp    fp, lr, [sp, #208]
 	.seh_save_fplr 208
 
@@ -110,7 +125,11 @@
 	ldp    \receiver, x8, [sp], #(ARGUMENT_SPILL_SIZE + 16)
 	.seh_stackalloc  (ARGUMENT_SPILL_SIZE + 16)
 
+	.seh_endepilogue
+
 	br     x9
+
+	.seh_endproc
 6:
 										  // Load 63:12 of SmallObjectClasses address
 										  // We use the CDECL macro as Windows prefixes
@@ -122,7 +141,7 @@
 	ldr    x9, [x10, x9, lsl #3]
 
 	b      1b
-	END_PROC(\fnname)
+	//.cfi_endproc
 .endm
 
 #ifdef _WIN64

--- a/objc_msgSend.aarch64.S
+++ b/objc_msgSend.aarch64.S
@@ -93,13 +93,12 @@
 	ldp    \receiver, x8, [sp], #(ARGUMENT_SPILL_SIZE + 16)
 	br     x9
 6:
-#if __ELF__
-	adrp   x10, :got:SmallObjectClasses
-	ldr    x10, [x10, :got_lo12:SmallObjectClasses]
+	// Load 63:12 of SmallObjectClasses address
+	adrp   x10, CDECL(SmallObjectClasses)
+	// Add lower 12-bits of SmallObjectClasses address to x10
+	add    x10, x10, :lo12:CDECL(SmallObjectClasses)
 	ldr    x9, [x10, x9, lsl #3]
-#else
-  adr    x9, CDECL(SmallObjectClasses)
-#endif
+
 	b      1b
 	.cfi_endproc
 .endm
@@ -119,6 +118,7 @@
 .type 32;
 .endef
 #endif
+
 .globl CDECL(objc_msgSend_fpret)
 TYPE_DIRECTIVE(CDECL(objc_msgSend_fpret), %function)
 .globl CDECL(objc_msgSend)
@@ -129,6 +129,7 @@ CDECL(objc_msgSend_fpret):
 CDECL(objc_msgSend_stret):
 CDECL(objc_msgSend):
 	MSGSEND objc_msgSend x0, x1
+
 #ifdef _WIN64
 .section        .drectve,"yn"
 .ascii  " /EXPORT:objc_msgSend"

--- a/objc_msgSend.aarch64.S
+++ b/objc_msgSend.aarch64.S
@@ -86,9 +86,11 @@
 
 	.seh_endprologue
 
+/*
 	.cfi_def_cfa fp, 16
 	.cfi_offset fp, -16
 	.cfi_offset lr, -8
+*/
 	
 	                                      // We now have all argument registers, the link
 	                                      // register and the receiver spilled on the
@@ -126,10 +128,9 @@
 	.seh_stackalloc  (ARGUMENT_SPILL_SIZE + 16)
 
 	.seh_endepilogue
+	.seh_endproc
 
 	br     x9
-
-	.seh_endproc
 6:
 										  // Load 63:12 of SmallObjectClasses address
 										  // We use the CDECL macro as Windows prefixes


### PR DESCRIPTION
This pull request provides initial support for Windows on ARM.

- Use [FlushInstructionCache](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-flushinstructioncache) instead of unsupported clear_cache intrinsic
(https://github.com/llvm/llvm-project/issues/58416)
- Add `ntdll.dll` to `target_link_libraries` as linker is unable to find `RtlRaiseException`
- Export symbols in `objc_msgSend.aarch64.S` (PE/COFF)
- Structured Exception Handling in `objc_msgSend.aarch64.S`

The code was tested on the following Systems:

1. Windows 10 Version 22598 MP (5 procs) Free ARM 64-bit (AArch64)
Edition build lab: 22598.1.arm64fre.ni_release.220408-1503
2. Debian GNU/Linux trixie/sid aarch64 (Kernel: 6.5.0-3-arm64)

I have documented the use of the SEH directives at the beginning of the file.

Further reading material (sorted by relevance):
- https://learn.microsoft.com/en-us/cpp/build/arm64-exception-handling?view=msvc-170
- https://github.com/llvm/llvm-project/commit/cbd8464595220b5ea76c70ac9965d84970c4b712
- https://www-user.tu-chemnitz.de/~heha/hsn/chm/Win32SEH.chm/Win32SEH.htm

Thank you @mstorsjo for the detailed explaination of the .seh* directives and the link to the LLVM commit.