### PR TITLE
CI: various improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,11 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  # Automatically run the workflow once a month
+  schedule:
+    - cron: '0 4 1 * *'
+  # Allow running the workflow manually
+  workflow_dispatch:
 
 jobs:
   ubuntu:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,19 +21,23 @@ jobs:
         os: [ "ubuntu-22.04", "ubuntu-20.04" ]
         build-type: [ Release, Debug ]
         cxxlib: [ "libc++", "libstdc++" ]
-        llvm-version: [10, 11, 12, 13, 14]
+        llvm-version: [10, 11, 12, 13, 14, 15]
         # Don't bother testing the LLVM versions that aren't in the default image for the different platforms
         exclude:
           - os: "ubuntu-22.04"
             llvm-version: 10
           - os: "ubuntu-22.04"
             llvm-version: 11
+          - os: "ubuntu-22.04"
+            llvm-version: 12
           - os: "ubuntu-20.04"
             llvm-version: 11
           - os: "ubuntu-20.04"
             llvm-version: 13
           - os: "ubuntu-20.04"
             llvm-version: 14
+          - os: "ubuntu-20.04"
+            llvm-version: 15
       # Don't abort runners if a single one fails
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/Test/UnexpectedException.m
+++ b/Test/UnexpectedException.m
@@ -1,5 +1,6 @@
 #include "Test.h"
 #include "../objc/hooks.h"
+#include "../objc/objc-exception.h"
 
 #include <stdlib.h>
 


### PR DESCRIPTION
- Schedule automatic runs on the 1st of every month at 4am.
- Enable running the workflow manually from the "Actions" tab on GitHub. This can be useful to re-run the CI on master or any other branch e.g. to see if any dependency changes. See https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow.
- Remove LLVM 12 on Ubuntu 22.04, as it doesn’t seem to be included in the default image any more.
- Add running with LLVM 15 on Ubuntu 22.04.
- Fix the UnexpectedException test on Windows failing due to a missing include (cherry picked commit by @hmelder). Not sure why this worked with the last CI run on master, unfortunately the logs are gone...