### PR TITLE
Tests: Append CMAKE_BINARY_DIR to PATH on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,7 +174,6 @@ jobs:
       shell: cmd
       working-directory: build
       run: |
-        copy /y objc.dll Test
         ctest -j 4 --output-on-failure -T test
 
 

--- a/README.windows
+++ b/README.windows
@@ -9,9 +9,3 @@ The runtime can build on Windows with Ninja:
 > cmake .. -G Ninja -DCMAKE_C_COMPILER=path/to/clang.exe -DCMAKE_CXX_COMPILER=path/to/clang.exe
 > ninja
 ```
-
-Debugging
----------
-
-The tests will all fail on Windows because they will not find objc.dll.
-To fix this, copy objc.dll into the `Tests` build directory.

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -127,6 +127,9 @@ function(addtest_flags TEST_NAME FLAGS TEST_SOURCE)
 	set_property(TEST ${TEST_NAME} PROPERTY
 		ENVIRONMENT "LD_LIBRARY_PATH=" "LLVM_PROFILE_FILE=${TEST_NAME}.profraw"
 	)
+	if(WIN32)
+		set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT_MODIFICATION "PATH=path_list_append:${CMAKE_BINARY_DIR}")
+	endif()
 	target_link_libraries(${TEST_NAME} objc)
 endfunction(addtest_flags)
 


### PR DESCRIPTION
Avoids copying objc.dll to the tests directory.