### PR TITLE
Don't set -fobjc-runtime=gnustep-2.0 as a global flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,6 @@ set(LIBOBJC_NAME "objc" CACHE STRING
 set(INCLUDE_DIRECTORY "objc" CACHE STRING 
 	"Subdirectory of the include path to install the headers.")
 
-add_compile_options("$<$<OR:$<COMPILE_LANGUAGE:OBJC>,$<COMPILE_LANGUAGE:OBJCXX>>:-Wno-deprecated-objc-isa-usage;-Wno-objc-root-class;-fobjc-runtime=gnustep-2.0>$<$<COMPILE_LANGUAGE:C>:-Xclang;-fexceptions>")
 add_compile_options($<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},i686>:-march=i586>)
 
 set(INSTALL_TARGETS objc)
@@ -227,6 +226,7 @@ else ()
 endif ()
 
 add_library(objc SHARED ${libobjc_C_SRCS} ${libobjc_ASM_SRCS} ${libobjc_OBJC_SRCS} ${libobjc_OBJCXX_SRCS} ${libobjc_ASM_OBJS})
+target_compile_options(objc PRIVATE "$<$<OR:$<COMPILE_LANGUAGE:OBJC>,$<COMPILE_LANGUAGE:OBJCXX>>:-Wno-deprecated-objc-isa-usage;-Wno-objc-root-class;-fobjc-runtime=gnustep-2.0>$<$<COMPILE_LANGUAGE:C>:-Xclang;-fexceptions>")
 
 list(APPEND libobjc_CXX_SRCS ${libobjcxx_CXX_SRCS})
 target_sources(objc PRIVATE ${libobjc_CXX_SRCS})

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -138,7 +138,9 @@ function(addtest_variants TEST TEST_SOURCE LEGACY)
 	target_sources(${TEST} PRIVATE $<TARGET_OBJECTS:test_runtime>)
 	addtest_flags("${TEST}_optimised" "-O3 -fobjc-runtime=gnustep-2.0 -UNDEBUG -DGS_RUNTIME_V2" "${TEST_SOURCE}")
 	target_sources("${TEST}_optimised" PRIVATE $<TARGET_OBJECTS:test_runtime>)
-	if (${LEGACY} AND ${OLDABI_COMPAT})
+
+	# -fobjc-arc is not supported on platforms using the legacy runtime
+	if (${LEGACY} AND ${OLDABI_COMPAT} AND NOT ${TEST} MATCHES ".*_arc")
 		addtest_flags("${TEST}_legacy" "-O0 -fobjc-runtime=gnustep-1.7 -UNDEBUG" "${TEST_SOURCE}")
 		target_sources("${TEST}_legacy" PRIVATE $<TARGET_OBJECTS:test_runtime_legacy>)
 		addtest_flags("${TEST}_legacy_optimised" "-O3 -fobjc-runtime=gnustep-1.7 -UNDEBUG" "${TEST_SOURCE}")


### PR DESCRIPTION
Calling:

```cmake
add_compile_options("$<$<OR:$<COMPILE_LANGUAGE:OBJC>,$<COMPILE_LANGUAGE:OBJCXX>>:-Wno-deprecated-objc-isa-usage;-Wno-objc-root-class;-fobjc-runtime=gnustep-2.0>$<$<COMPILE_LANGUAGE:C>:-Xclang;-fexceptions>")
```

in `CMakeLists.txt` will add `-fobjc-runtime=gnustep-2.0` as a compile option for all builds.  The legacy tests will attempt to target `gnustep-1.7` by calling:

```cmake
addtest_flags("${TEST}_legacy" "-O0 -fobjc-runtime=gnustep-1.7 -UNDEBUG" "${TEST_SOURCE}")
```

which will result in the same flag being defined twice (`-fobjc-runtime=gnustep-2.0 -fobjc-runtime=gnustep-1.7`).  In my setup, that resulted in clang targeting the 2.0 runtime, making the legacy tests invalid.