### PR TITLE
Update FreeBSD versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,14 +1,12 @@
 freebsd_instance:
-  image: freebsd-12-3-release-amd64
+  image: freebsd-13-2-release-amd64
 
 libcxxrt_freebsd_task:
   matrix:
   - freebsd_instance:
-     image_family: freebsd-13-1
+     image_family: freebsd-13-2
   - freebsd_instance:
-     image_family: freebsd-12-3
-  - freebsd_instance:
-     image_family: freebsd-14-0-snap
+     image_family: freebsd-14-0
 
   install_script: pkg install -y cmake ninja git
 


### PR DESCRIPTION
Match latest versions at https://www.freebsd.org/releases/, 12.4 went EOL on 31-dec-23: https://www.freebsd.org/security/#sup