### PR TITLE
Add domestic exception handling support for MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,12 @@ else()
 	set(OLD_ABI_COMPAT_DEFAULT true)
 endif()
 
+if (MINGW)
+	set(ENABLE_OBJCXX_DEFAULT false)
+else()
+	set(ENABLE_OBJCXX_DEFAULT true)
+endif()
+
 option(TYPE_DEPENDENT_DISPATCH "Enable type-dependent dispatch" ON)
 option(ENABLE_TRACING 
 	"Enable tracing support (slower, not recommended for deployment)" OFF)
@@ -147,7 +153,8 @@ option(OLDABI_COMPAT
 option(LEGACY_COMPAT "Enable legacy compatibility features" OFF)
 option(DEBUG_ARC_COMPAT
 	"Log warnings for classes that don't hit ARC fast paths" OFF)
-option(ENABLE_OBJCXX "Enable support for Objective-C++" ON)
+option(ENABLE_OBJCXX "Enable support for Objective-C++"
+	${ENABLE_OBJCXX_DEFAULT})
 option(TESTS "Enable building the tests")
 
 
@@ -157,6 +164,10 @@ add_compile_definitions($<$<CONFIG:Release>:NO_SELECTOR_MISMATCH_WARNINGS>)
 add_compile_definitions($<$<BOOL:${TYPE_DEPENDENT_DISPATCH}>:TYPE_DEPENDENT_DISPATCH>)
 add_compile_definitions($<$<BOOL:${ENABLE_TRACING}>:WITH_TRACING=1>)
 add_compile_definitions($<$<BOOL:${DEBUG_ARC_COMPAT}>:DEBUG_ARC_COMPAT>)
+
+if (ENABLE_OBJCXX AND MINGW)
+	message(FATAL_ERROR "Objective-C++ is not supported on MinGW.")
+endif()
 
 if (OLDABI_COMPAT)
 	list(APPEND libobjc_C_SRCS legacy.c abi_version.c statics_loader.c)

--- a/eh_personality.c
+++ b/eh_personality.c
@@ -415,10 +415,7 @@ static inline _Unwind_Reason_Code internal_objc_personality(int version,
 #ifndef NO_OBJCXX
 	if (cxx_exception_class == 0)
 	{
-#ifndef __MINGW32__
-		// FIXME: This is currently broken with MinGW
 		test_cxx_eh_implementation();
-#endif
 	}
 
 	if (exceptionClass == cxx_exception_class)

--- a/eh_personality.c
+++ b/eh_personality.c
@@ -218,7 +218,7 @@ void objc_exception_rethrow(struct _Unwind_Exception *e);
  * rethrowing caught exceptions too, even in @finally() blocks.  Unfortunately,
  * this means that we have some problems if the exception is boxed.
  */
-void objc_exception_throw(id object)
+OBJC_PUBLIC void objc_exception_throw(id object)
 {
 	struct thread_data *td = get_thread_data();
 	DEBUG_LOG("Throwing %p, in flight exception: %p\n", object, td->lastThrownObject);

--- a/eh_personality.c
+++ b/eh_personality.c
@@ -415,7 +415,10 @@ static inline _Unwind_Reason_Code internal_objc_personality(int version,
 #ifndef NO_OBJCXX
 	if (cxx_exception_class == 0)
 	{
+#ifndef __SEH__
+		// FIXME: This is currently broken with MinGW
 		test_cxx_eh_implementation();
+#endif
 	}
 
 	if (exceptionClass == cxx_exception_class)

--- a/eh_personality.c
+++ b/eh_personality.c
@@ -8,6 +8,14 @@
 #include "class.h"
 #include "objcxx_eh.h"
 
+#if defined(__SEH__) && !defined(__USING_SJLJ_EXCEPTIONS__)
+#include <windows.h>
+#include <winnt.h>
+
+EXCEPTION_DISPOSITION _GCC_specific_handler(PEXCEPTION_RECORD, void *, PCONTEXT,
+                                            PDISPATCHER_CONTEXT, void *);
+#endif
+
 #ifndef DEBUG_EXCEPTIONS
 #define DEBUG_LOG(...)
 #else
@@ -602,6 +610,16 @@ BEGIN_PERSONALITY_FUNCTION(__gnustep_objcxx_personality_v0)
 #endif
 	return CALL_PERSONALITY_FUNCTION(__gxx_personality_v0);
 }
+
+#if defined(__SEH__) && !defined(__USING_SJLJ_EXCEPTIONS__)
+OBJC_PUBLIC EXCEPTION_DISPOSITION
+__gnu_objc_personality_seh0(PEXCEPTION_RECORD ms_exc, void *this_frame,
+		PCONTEXT ms_orig_context, PDISPATCHER_CONTEXT ms_disp)
+{
+	return _GCC_specific_handler(ms_exc, this_frame, ms_orig_context, ms_disp,
+			__gnustep_objc_personality_v0);
+}
+#endif
 
 OBJC_PUBLIC id objc_begin_catch(struct _Unwind_Exception *exceptionObject)
 {

--- a/eh_personality.c
+++ b/eh_personality.c
@@ -14,6 +14,7 @@
 
 EXCEPTION_DISPOSITION _GCC_specific_handler(PEXCEPTION_RECORD, void *, PCONTEXT,
                                             PDISPATCHER_CONTEXT, void *);
+DECLARE_PERSONALITY_FUNCTION(test_eh_personality_internal);
 #endif
 
 #ifndef DEBUG_EXCEPTIONS
@@ -211,7 +212,7 @@ static void cleanup(_Unwind_Reason_Code reason, struct _Unwind_Exception *e)
 					*/
 }
 
-void objc_exception_rethrow(struct _Unwind_Exception *e);
+OBJC_PUBLIC void objc_exception_rethrow(struct _Unwind_Exception *e);
 
 /**
  * Throws an Objective-C exception.  This function is, unfortunately, used for
@@ -618,6 +619,13 @@ __gnu_objc_personality_seh0(PEXCEPTION_RECORD ms_exc, void *this_frame,
 {
 	return _GCC_specific_handler(ms_exc, this_frame, ms_orig_context, ms_disp,
 			__gnustep_objc_personality_v0);
+}
+PRIVATE EXCEPTION_DISPOSITION
+test_eh_personality(PEXCEPTION_RECORD ms_exc, void *this_frame,
+		PCONTEXT ms_orig_context, PDISPATCHER_CONTEXT ms_disp)
+{
+	return _GCC_specific_handler(ms_exc, this_frame, ms_orig_context, ms_disp,
+			test_eh_personality_internal);
 }
 #endif
 

--- a/objcxx_eh.cc
+++ b/objcxx_eh.cc
@@ -448,7 +448,11 @@ PRIVATE void cxx_throw()
  */
 extern "C"
 PRIVATE
+#ifdef __SEH__
+BEGIN_PERSONALITY_FUNCTION(test_eh_personality_internal)
+#else
 BEGIN_PERSONALITY_FUNCTION(test_eh_personality)
+#endif
 	// Don't bother with a mutex here.  It doesn't matter if two threads set
 	// these values at the same time.
 	if (!done_setup)


### PR DESCRIPTION
This is the exception-handling related part of #190. 

It:
- Implements `__gnu_objc_personality_seh0` which uses `_GCC_specific_handler` to call `__gnustep_objc_personality_v0`
- As a special case, when compiling on MinGW, renames `__gnustep_objc_personality_v0` to `__gnustep_objc_personality_v0_internal` and implements `__gnustep_objc_personality_v0` with the same semantics as `__gnu_objc_personality_seh0` (for clang support).  This special case can be removed when clang knows about MinGW support in libobjc and directly invokes `__gnu_objc_personality_seh0`.

which brings basic try/catch support to objc2 on MinGW. C++ exception interop is still not implemented.

When running the tests, 89% tests passed, with all failures being related to exception interop:
- UnexpectedException (Exit code 0xc0000409)
- CXXExceptions (Exit code 0xc0000374)
- ObjCXXEHInterop (SEGFAULT)
- ObjCXXEHInteropTwice (SEGFAULT)
- ObjCXXEHInterop_arc (SEGFAULT)

Notable passing tests are ExceptionTest, NestedExceptions, NilException, objc_msgSend and RuntimeTest