### PR TITLE
MinGW: Add exception-handling façades to libobjc2

### DIFF
--- a/fast_paths.m
+++ b/fast_paths.m
@@ -12,6 +12,7 @@ typedef struct _NSZone NSZone;
 /**
  * Equivalent to [cls alloc].  If there's a fast path opt-in, then this skips the message send.
  */
+OBJC_PUBLIC
 id
 objc_alloc(Class cls)
 {
@@ -29,6 +30,7 @@ objc_alloc(Class cls)
 /**
  * Equivalent to [cls allocWithZone: null].  If there's a fast path opt-in, then this skips the message send.
  */
+OBJC_PUBLIC
 id
 objc_allocWithZone(Class cls)
 {
@@ -47,6 +49,7 @@ objc_allocWithZone(Class cls)
  * Equivalent to [[cls alloc] init].  If there's a fast path opt-in, then this
  * skips the message send.
  */
+OBJC_PUBLIC
 id
 objc_alloc_init(Class cls)
 {

--- a/objcxx_eh.h
+++ b/objcxx_eh.h
@@ -14,7 +14,6 @@ extern "C" {
 #undef CXA_ALLOCATE_EXCEPTION_SPECIFIER
 #define CXA_ALLOCATE_EXCEPTION_SPECIFIER
 #endif
-__attribute__((weak))
 void *__cxa_allocate_exception(size_t thrown_size) CXA_ALLOCATE_EXCEPTION_SPECIFIER;
 
 /**
@@ -23,7 +22,6 @@ void *__cxa_allocate_exception(size_t thrown_size) CXA_ALLOCATE_EXCEPTION_SPECIF
  * _Unwind_Exception structure within this structure, and should be passed to
  * the C++ personality function.
  */
-__attribute__((weak))
 struct _Unwind_Exception *objc_init_cxx_exception(id thrown_exception);
 /**
  * The GNU C++ exception personality function, provided by libsupc++ (GNU) or
@@ -34,21 +32,18 @@ __attribute__((weak)) DECLARE_PERSONALITY_FUNCTION(__gxx_personality_v0);
  * Frees an exception object allocated by __cxa_allocate_exception().  Part of
  * the Itanium C++ ABI.
  */
-__attribute__((weak))
 void __cxa_free_exception(void *thrown_exception);
 /**
  * Tests whether a C++ exception contains an Objective-C object, and returns if
  * if it does.  The second argument is a pointer to a boolean value indicating
  * whether this is a valid object.
  */
-__attribute__((weak))
 void *objc_object_for_cxx_exception(void *thrown_exception, int *isValid);
 
 /**
  * Prints the type info associated with an exception.  Used only when
  * debugging, not compiled in the normal build.
  */
-__attribute__((weak))
 void print_type_info(void *thrown_exception);
 
 /**

--- a/objcxx_eh_mingw.cc
+++ b/objcxx_eh_mingw.cc
@@ -1,6 +1,7 @@
 #include <atomic>
 #include <stdlib.h>
 #include <stdio.h>
+#include <windows.h>
 #include "dwarf_eh.h"
 #include "objcxx_eh_private.h"
 #include "objcxx_eh.h"
@@ -95,4 +96,46 @@ void objc_exception_throw(id object)
 OBJC_PUBLIC extern objc_uncaught_exception_handler objc_setUncaughtExceptionHandler(objc_uncaught_exception_handler handler)
 {
 	return __atomic_exchange_n(&_objc_unexpected_exception, handler, __ATOMIC_SEQ_CST);
+}
+
+extern "C" void* __cxa_begin_catch(void *object);
+
+extern "C"
+OBJC_PUBLIC
+void* objc_begin_catch(void* object)
+{
+	return __cxa_begin_catch(object);
+}
+
+extern "C" void __cxa_end_catch();
+
+extern "C"
+OBJC_PUBLIC
+void objc_end_catch()
+{
+	__cxa_end_catch();
+}
+
+extern "C" void __cxa_rethrow();
+
+extern "C"
+OBJC_PUBLIC
+void objc_exception_rethrow()
+{
+	__cxa_rethrow();
+}
+
+extern "C" EXCEPTION_DISPOSITION __gxx_personality_seh0(PEXCEPTION_RECORD ms_exc,
+														void *this_frame,
+														PCONTEXT ms_orig_context,
+														PDISPATCHER_CONTEXT ms_disp);
+
+extern "C"
+OBJC_PUBLIC
+EXCEPTION_DISPOSITION __gnu_objc_personality_seh0(PEXCEPTION_RECORD ms_exc,
+														void *this_frame,
+														PCONTEXT ms_orig_context,
+														PDISPATCHER_CONTEXT ms_disp)
+{
+  return __gxx_personality_seh0(ms_exc, this_frame, ms_orig_context, ms_disp);
 }


### PR DESCRIPTION
The current implementation uses functions which are declared in the 
C++ standard library to throw and catch exceptions.
This requires linking with said library, which most toolchains do not
do natively.