### PR TITLE
Support Control Flow Enforcement with Indirect Branch Tracking

### DIFF
--- a/block_trampolines.S
+++ b/block_trampolines.S
@@ -23,6 +23,7 @@
 // x86-64 trampoline
 ////////////////////////////////////////////////////////////////////////////////
 .macro trampoline arg0, arg1
+	endbr64
 	mov   -0x1007(%rip), \arg1   # Load the block pointer into the second argument
 	xchg  \arg1, \arg0           # Swap the first and second arguments
 	jmp   *-0x1008(%rip)         # Call the block function
@@ -161,6 +162,7 @@
 // AArch64 (ARM64) trampoline
 ////////////////////////////////////////////////////////////////////////////////
 .macro trampoline arg0, arg1
+	bti c
 	adr x17, #-4096
 	mov \arg1, \arg0
 	ldp \arg0, x17, [x17]

--- a/objc_msgSend.aarch64.S
+++ b/objc_msgSend.aarch64.S
@@ -47,7 +47,7 @@
 #   define EH_NOP .seh_nop
 #else
 // Marks the real start and end of the function
-#   define EH_START .cfi_startproc
+#   define EH_START .cfi_startproc; bti c
 #   define EH_END .cfi_endproc
 
 // The following directives are either not

--- a/objc_msgSend.x86-64.S
+++ b/objc_msgSend.x86-64.S
@@ -8,7 +8,7 @@
 #	define SECOND_ARGUMENT %rdx
 #	define THIRD_ARGUMENT %r8
 #else
-#	define START_PROC(x) .cfi_startproc
+#	define START_PROC(x) .cfi_startproc; endbr64
 #	define END_PROC(x) .cfi_endproc
 #	define FRAME_OFFSET(x) .cfi_adjust_cfa_offset x
 #	define FIRST_ARGUMENT_STR "%rdi"


### PR DESCRIPTION
This is enforced on OpenBSD platforms/hardware that supports it, namely Intel gen11 or newer (amd64), or Apple M2 (aarch64).

Patch is needed to let GNUstep applications work on such machines. I don't have such "modern" hardware, but some minimal tests at least on an amd64 box that supports it done. aarch64 may need more to make it work properly.

More see threat: https://marc.info/?t=170974826400001&r=1&w=2