### PR TITLE
Whitelist UnexpectedException test for all architectures and recommend libunwind in INSTALL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 [b|B]uild
 Debug
 Release
+.cache

--- a/INSTALL
+++ b/INSTALL
@@ -6,6 +6,14 @@ runtime.  Note that although this runtime should build with gcc, it is strongly
 recommended that you compile it with clang and clang++ as your [Objective-]C and
 [Objective-]C++ compilers.
 
+It is recommended that you use the LLVM runtime and unwinder or a recent version
+of GCC (>= 14) on GNU/Linux to avoid a
+[bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114843) in GCC and the libgcc
+unwinder.
+
+If CompilerRT and libunwind are installed on your machine use
+`-DCMAKE_EXE_LINKER_FLAGS="-rtlib=compiler-rt -unwindlib=libunwind"`.
+
 Basic Building
 --------------
 

--- a/Test/UnexpectedException.m
+++ b/Test/UnexpectedException.m
@@ -31,7 +31,6 @@ LONG WINAPI _UnhandledExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo)
 
 int main(void)
 {
-#if !(defined(__arm__) || defined(__ARM_ARCH_ISA_A64)) && !defined(__powerpc__)
 #if defined(_WIN32) && !defined(__MINGW32__)
 	// also verify that an existing handler still gets called after we set ours
 	SetUnhandledExceptionFilter(&_UnhandledExceptionFilter);
@@ -50,7 +49,4 @@ int main(void)
 	assert(0 && "should not be reached!");
 
 	return -1;
-#endif
-	// FIXME: Test currently fails on ARM and AArch64
-	return 77; // Skip test
 }


### PR DESCRIPTION
I am undecided about whether to add a try_compile to the CMakeLists.txt to automatically use CompilerRT and libunwind if they are available. This should exclude Windows and Android.

This PR should be merged after a fix for [libgcc: _Unwind_RaiseException corrupts return value](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114843) is implemented in GCC.