### PR TITLE
Fix issue with BOOL on Windows

### DIFF
--- a/objc/runtime.h
+++ b/objc/runtime.h
@@ -131,7 +131,7 @@ typedef struct objc_method *Method;
 #	ifdef STRICT_APPLE_COMPATIBILITY
 typedef signed char BOOL;
 #	else
-#		if defined(__vxworks) || defined(_WIN32)
+#		if defined(__vxworks)
 typedef  int BOOL;
 #		else
 typedef unsigned char BOOL;


### PR DESCRIPTION
BOOL on GNUstep platforms is defined as unsigned char except on vxworks. Having this _WIN32 flag means that GNUstep GUI gorm files will not work as they are expecting unsigned char for bool.