### PR TITLE
Windows: Support building with strict compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,6 +213,7 @@ jobs:
         os: [ windows-2019 ]
         msystem: [ ucrt64, mingw64, clang64 ]
         build-type: [ Release, Debug ]
+        strict-apple-compatibility: [ ON, OFF ]
         include:
           - msystem: ucrt64
             package-prefix: ucrt-x86_64
@@ -226,7 +227,7 @@ jobs:
       # Don't abort runners if a single one fails
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} ${{ matrix.msystem }} ${{ matrix.build-type}}
+    name: ${{ matrix.os }} ${{ matrix.msystem }} ${{ matrix.build-type}} (Strict Apple compatibility ${{ matrix.strict-apple-compatibility }})
     defaults:
       run:
         shell: msys2 {0}
@@ -241,7 +242,7 @@ jobs:
       run: |        
         mkdir build
         cd build
-        ${{ matrix.cmake-flags }} cmake .. -DTESTS=ON -DCMAKE_C_COMPILER="clang" -DCMAKE_CXX_COMPILER="clang++" -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
+        ${{ matrix.cmake-flags }} cmake .. -DTESTS=ON -DCMAKE_C_COMPILER="clang" -DCMAKE_CXX_COMPILER="clang++" -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DSTRICT_APPLE_COMPATIBILITY=${{ matrix.strict-apple-compatibility }}
     - name: Build
       working-directory: build
       run: |
@@ -256,7 +257,7 @@ jobs:
         cmake --install . --prefix=../dist
     - uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.msystem }}-${{ matrix.build-type }}
+        name: ${{ matrix.msystem }}-${{ matrix.build-type }}-compat-${{ matrix.strict-apple-compatibility }}
         path: dist/
 
   android:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 message(STATUS "Architecture as detected by CMake: ${CMAKE_SYSTEM_PROCESSOR}")
 
 # Build configuration
-add_compile_definitions(GNUSTEP __OBJC_RUNTIME_INTERNAL__=1)
+add_compile_definitions(GNUSTEP __OBJC_RUNTIME_INTERNAL__=1 __OBJC_BOOL)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -140,6 +140,7 @@ option(DEBUG_ARC_COMPAT
 option(ENABLE_OBJCXX "Enable support for Objective-C++" ON)
 option(TESTS "Enable building the tests")
 option(EMBEDDED_BLOCKS_RUNTIME "Include an embedded blocks runtime, rather than relying on libBlocksRuntime to supply it" ON)
+option(STRICT_APPLE_COMPATIBILITY "Use strict Apple compatibility, always defining BOOL as signed char" OFF)
 
 # For release builds, we disable spamming the terminal with warnings about
 # selector type mismatches
@@ -147,6 +148,7 @@ add_compile_definitions($<$<CONFIG:Release>:NO_SELECTOR_MISMATCH_WARNINGS>)
 add_compile_definitions($<$<BOOL:${TYPE_DEPENDENT_DISPATCH}>:TYPE_DEPENDENT_DISPATCH>)
 add_compile_definitions($<$<BOOL:${ENABLE_TRACING}>:WITH_TRACING=1>)
 add_compile_definitions($<$<BOOL:${DEBUG_ARC_COMPAT}>:DEBUG_ARC_COMPAT>)
+add_compile_definitions($<$<BOOL:${STRICT_APPLE_COMPATIBILITY}>:STRICT_APPLE_COMPATIBILITY>)
 
 if (OLDABI_COMPAT)
 	list(APPEND libobjc_C_SRCS legacy.c abi_version.c statics_loader.c)


### PR DESCRIPTION
This commit adds the `STRICT_APPLE_COMPATIBILITY` CMake option which will force `BOOL` to defined as an `signed char` on Windows instead of an `int`, as having different types for `BOOL` on different platforms creates serialization issues.

On MSYS, the `BOOL` type is defined in` minwindef` like this:

```
#if !defined(__OBJC__) && !defined(__OBJC_BOOL) && !defined(__objc_INCLUDE_GNU) && !defined(_NO_BOOL_TYPEDEF)
  typedef int BOOL;
#endif
```

To prevent this header from defining a conflicting `BOOL` type, this commit also defines `__OBJC_BOOL`.