### PR TITLE
Fix selector forwarding on x64 Windows

### DIFF
--- a/Test/Forward.m
+++ b/Test/Forward.m
@@ -18,14 +18,24 @@ id target;
 @end
 
 @interface ForwardingTarget : Test
+{
+  int y;
+}
 @end
 
 BOOL forwardingTargetCalled;
 
 @implementation ForwardingTarget
+- (id)init
+{
+	y = 42;
+	return self;
+}
+
 - (void)foo: (int)x
 {
 	assert(x == 42);
+	assert(x == y);
 	forwardingTargetCalled = YES;
 }
 @end
@@ -58,7 +68,7 @@ int main(void)
 {
 	objc_proxy_lookup = proxy_lookup;
 	__objc_msg_forward2 = forward;
-	target = [ForwardingTarget new];
+	target = [[ForwardingTarget new] init];
 	id proxy = [Forward new];
 	[proxy foo: 42];
 	[proxy dealloc];

--- a/objc_msgSend.x86-64.S
+++ b/objc_msgSend.x86-64.S
@@ -7,6 +7,7 @@
 #	define FIRST_ARGUMENT %rcx
 #	define SECOND_ARGUMENT %rdx
 #	define THIRD_ARGUMENT %r8
+#	define FOURTH_ARGUMENT %r9
 #else
 #	define START_PROC(x) .cfi_startproc
 #	define END_PROC(x) .cfi_endproc
@@ -15,6 +16,7 @@
 #	define FIRST_ARGUMENT %rdi
 #	define SECOND_ARGUMENT %rsi
 #	define THIRD_ARGUMENT %rdx
+#	define FOURTH_ARGUMENT %rcx
 #endif
 
 .macro MSGSEND fnname receiver, sel
@@ -209,7 +211,7 @@
 5:                                       # slowSend:
 	push  %rax                           # We need to preserve all registers that may contain arguments:
 	push  %rbx
-	push  %rcx
+	push  FOURTH_ARGUMENT
 	push  %r8
 	push  %r9
 	
@@ -258,7 +260,7 @@
 
 	pop   %r9
 	pop   %r8
-	pop   %rcx
+	pop   FOURTH_ARGUMENT
 	pop   %rbx
 	pop   %rax
 	jmp   7b


### PR DESCRIPTION
As described in #312, selector forwarding does not appear to be working correctly on Windows.  This becomes apparent when accessing `[self]`.  This PR updates the Forward test to access an instance variable, exposing the issue, and proposes a fix.

The root cause appears to be that the `rcx` register is being overwritten after `slowMsgLookup` returns.  On Unix, `rcx` is the fourth argument; on Windows, it is the first argument. Introduce a `FOURTH_ARGUMENT` variable to ensure we use `rcx` on Unix and `r9` on Windows to refer to the fourth argument.

Closes #312