### PR TITLE
Retrieve class of instance in objc_alloc_init

### DIFF
--- a/Test/FastPathAlloc.m
+++ b/Test/FastPathAlloc.m
@@ -21,6 +21,8 @@ typedef struct _NSZone NSZone;
 @interface NoInit : Test @end
 @interface NoInit2 : NoInit @end
 
+@interface ShouldInitSubclassed : NoInit @end
+
 @implementation ShouldAlloc
 + (instancetype)alloc
 {
@@ -91,6 +93,13 @@ typedef struct _NSZone NSZone;
 }
 @end
 
+@implementation ShouldInitSubclassed
++ (instancetype) alloc
+{
+	return [ShouldInit alloc];
+}
+@end
+
 Class getClassNamed(char *name)
 {
 	return nil;
@@ -112,6 +121,10 @@ int main(void)
 
 	called = NO;
 	[[ShouldInit2 alloc] init];
+	assert(called);
+
+	called = NO;
+	[[ShouldInitSubclassed alloc] init];
 	assert(called);
 
 	called = NO;

--- a/fast_paths.m
+++ b/fast_paths.m
@@ -9,9 +9,6 @@ typedef struct _NSZone NSZone;
 @end
 #include <stdio.h>
 
-/**
- * Equivalent to [cls alloc].  If there's a fast path opt-in, then this skips the message send.
- */
 OBJC_PUBLIC
 id
 objc_alloc(Class cls)
@@ -66,6 +63,9 @@ objc_alloc_init(Class cls)
 		return nil;
 	}
 	id instance = objc_alloc(cls);
+	// If +alloc was overwritten, it is not guaranteed that it returns
+	// an instance of cls.
+	cls = classForObject(instance);
 	if (objc_test_class_flag(cls, objc_class_flag_fast_alloc_init))
 	{
 		return instance;


### PR DESCRIPTION
If +alloc was overwritten, it is not guaranteed that it returns an instance of cls. For example, a class cluster like NSString might return an instance of a subclass instead.
Retrieve the class of the instance returned by objc_alloc instead.