### PR TITLE
Fix leak of weak references

### DIFF
--- a/arc.mm
+++ b/arc.mm
@@ -838,8 +838,9 @@ extern "C" OBJC_PUBLIC id objc_storeWeak(id *addr, id obj)
 	WeakRef *oldRef;
 	id old;
 	loadWeakPointer(addr, &old, &oldRef);
-	// If the old and new values are the same, then we don't need to do anything.
-	if (old == obj)
+	// If the old and new values are the same, then we don't need to do anything
+	// unless we are deleting the weak reference by storing NULL to it.
+	if (old == obj && (obj != NULL || NULL == oldRef))
 	{
 		return obj;
 	}

--- a/arc.mm
+++ b/arc.mm
@@ -840,7 +840,7 @@ extern "C" OBJC_PUBLIC id objc_storeWeak(id *addr, id obj)
 	loadWeakPointer(addr, &old, &oldRef);
 	// If the old and new values are the same, then we don't need to do anything
 	// unless we are deleting the weak reference by storing NULL to it.
-	if (old == obj && (obj != NULL || NULL == oldRef))
+	if ((old == obj) && ((obj != NULL) || (NULL == oldRef)))
 	{
 		return obj;
 	}


### PR DESCRIPTION
In the case where an object has been deallocated, fetching the old value of a weak reference to it returns nil.  If we are assigning nil to the weak reference we can't abort processing early (when we check that old and new values are the same) as that will leave the weak reference in place when the calling code thinks it has destroyed it.