### PR TITLE
Update encoding2.c - pass pointer to parse_array, not address of pointer

### DIFF
--- a/encoding2.c
+++ b/encoding2.c
@@ -333,7 +333,7 @@ static const char *alignof_type(const char *type, size_t *align)
 		case '[':
 		{
 			const char *t = type;
-			parse_array(&t, (type_parser)alignof_type, &align);
+			parse_array(&t, (type_parser)alignof_type, align);
 			return t;
 		}
 		case 'b':


### PR DESCRIPTION
&align results in the value being written to the calling routine's stack-bound argument, not the actual value of align.
(Closes #337)