### PR TITLE
Support 16 KiB Pages on AArch64 Targets

### DIFF
--- a/block_to_imp.c
+++ b/block_to_imp.c
@@ -206,7 +206,17 @@ static void *trampoline_end_sret;
 PRIVATE void init_trampolines(void)
 {
 	// Retrieve the page size
+	#if defined(__powerpc64__)
+	// For PowerPC we fix the page size to 64KiB.
+	// We therefore effectively support all systems with page size <= 64 KiB.
+	trampoline_page_size = 0x10000;
+	// Check that the pagesize is greater or equal to the smallest size that we
+	// can perform mprotect operations on.
+	assert(pagesize() <= trampoline_page_size);
+	#else
 	trampoline_page_size = pagesize();
+	#endif
+
 	trampoline_region_size = trampoline_page_size * TRAMPOLINE_REGION_PAGES;
 	trampoline_header_per_page = trampoline_page_size / sizeof(struct block_header);
 

--- a/block_to_imp.c
+++ b/block_to_imp.c
@@ -20,11 +20,28 @@
 #include "blocks_runtime.h"
 #include "lock.h"
 #include "visibility.h"
-#include "asmconstants.h" // For PAGE_SIZE
 
 #ifndef __has_builtin
 #define __has_builtin(x) 0
 #endif
+
+#if defined(_WIN32)
+long pagesize(void)
+{
+  SYSTEM_INFO si;
+  GetSystemInfo(&si);
+
+  DWORD page_size = si.dwPageSize;
+  assert(page_size <= INT_MAX);
+
+  return (int)page_size;
+}
+#else
+long pagesize(void)
+{
+    return sysconf(_SC_PAGESIZE);
+}
+#endif // defined(_WIN32)
 
 #if defined(_WIN32) && (defined(__arm__) || defined(__aarch64__))
     static inline void __clear_cache(void* start, void* end) {
@@ -100,7 +117,7 @@ struct block_header
 {
 	void *block;
 	void(*fnptr)(void);
-	/**
+	/*
 	 * On 64-bit platforms, we have 16 bytes for instructions, which ought to
 	 * be enough without padding.
 	 * Note: If we add too much padding, then we waste space but have no other
@@ -115,38 +132,53 @@ struct block_header
 	 */
 #if defined(__i386__) || (defined(__mips__) && !defined(__mips_n64)) || (defined(__powerpc__) && !defined(__powerpc64__))
 	uint64_t padding[3];
-#elif defined(__mips__) || defined(__powerpc64__)
+#elif defined(__mips__) || defined(__ARM_ARCH_ISA_A64) || defined(__powerpc64__)
 	uint64_t padding[2];
 #elif defined(__arm__)
 	uint64_t padding;
 #endif
 };
 
-#define HEADERS_PER_PAGE (PAGE_SIZE/sizeof(struct block_header))
-
-/**
- * Structure containing a two pages of block trampolines.  Each trampoline
- * loads its block and target method address from the corresponding
- * block_header (one page before the start of the block structure).
- */
-struct trampoline_buffers
-{
-	struct block_header  headers[HEADERS_PER_PAGE];
-	char                 rx_buffer[PAGE_SIZE];
-};
-_Static_assert(__builtin_offsetof(struct trampoline_buffers, rx_buffer) == PAGE_SIZE,
-	"Incorrect offset for read-execute buffer");
-_Static_assert(sizeof(struct trampoline_buffers) == 2*PAGE_SIZE,
-	"Incorrect size for trampoline buffers");
-
 struct trampoline_set
 {
-	struct trampoline_buffers *buffers;
-	struct trampoline_set     *next;
+	/*
+	* Each trampoline loads its block and target method address
+	* from the corresponding block_header
+	* (one page before the start of the block structure).
+	*
+	* Page | Description
+	*    1 | Page filled with block_header's
+	*    2 | RX buffer page
+	*/
+	char  *region;
+	struct trampoline_set *next;
 	int first_free;
 };
 
+
+/*
+ * Current page size of the system in bytes.
+ * Set in init_trampolines.
+ */
+static int trampoline_page_size;
+/*
+ * Number of block_header's per page.
+ * Calculated in init_trampolines after retrieving the current page size:
+ */
+static size_t trampoline_header_per_page;
+/*
+ * Size of a trampoline region in bytes.
+ */
+static size_t trampoline_region_size;
 static mutex_t trampoline_lock;
+
+/*
+ * Size of the trampoline region (in pages)
+ */
+#define TRAMPOLINE_REGION_PAGES 2
+
+#define REGION_HEADERS_START(metadata) ((struct block_header *) metadata->region)
+#define REGION_RX_BUFFER_START(metadata) (metadata->region + trampoline_page_size)
 
 struct wx_buffer
 {
@@ -158,10 +190,60 @@ extern char __objc_block_trampoline_end;
 extern char __objc_block_trampoline_sret;
 extern char __objc_block_trampoline_end_sret;
 
+#if defined(__ARM_ARCH_ISA_A64)
+extern char __objc_block_trampoline_16;
+extern char __objc_block_trampoline_end_16;
+extern char __objc_block_trampoline_sret_16;
+extern char __objc_block_trampoline_end_sret_16;
+#endif
+
+// Cache the correct trampoline region
+static void *trampoline_start;
+static void *trampoline_end;
+static void *trampoline_start_sret;
+static void *trampoline_end_sret;
+
 PRIVATE void init_trampolines(void)
 {
-	assert(&__objc_block_trampoline_end - &__objc_block_trampoline <= sizeof(struct block_header));
-	assert(&__objc_block_trampoline_end_sret - &__objc_block_trampoline_sret <= sizeof(struct block_header));
+	// Retrieve the page size
+	trampoline_page_size = pagesize();
+	trampoline_region_size = trampoline_page_size * TRAMPOLINE_REGION_PAGES;
+	trampoline_header_per_page = trampoline_page_size / sizeof(struct block_header);
+
+	// Check that sizeof(struct block_header) is a divisor of the current page size
+	assert(trampoline_header_per_page * sizeof(struct block_header) == trampoline_page_size);
+
+    // Check that assumptions for all non-variable page size implementations
+	// (currently everything except AArch64) are met
+#if defined(__powerpc64__)
+	assert(trampoline_page_size == 0x10000);
+#elif defined(__ARM_ARCH_ISA_A64)
+	assert(trampoline_page_size == 0x1000 || trampoline_page_size == 0x4000);
+#else
+	assert(trampoline_page_size == 0x1000);
+#endif
+
+	// Select the correct trampoline for our page size
+#if defined(__ARM_ARCH_ISA_A64)
+	if (trampoline_page_size == 0x4000) {
+		trampoline_start = &__objc_block_trampoline_16;
+		trampoline_end = &__objc_block_trampoline_end_16;
+		trampoline_start_sret = &__objc_block_trampoline_sret_16;
+		trampoline_end_sret = &__objc_block_trampoline_end_sret_16;
+	} else {
+#else
+	{
+#endif
+		trampoline_start = &__objc_block_trampoline;
+		trampoline_end = &__objc_block_trampoline_end;
+		trampoline_start_sret = &__objc_block_trampoline_sret;
+		trampoline_end_sret = &__objc_block_trampoline_end_sret;
+	}	
+
+	// Check that we can fit the body of the trampoline function inside a block_header
+	assert(trampoline_end - trampoline_start <= sizeof(struct block_header));
+	assert(trampoline_end_sret - trampoline_start_sret <= sizeof(struct block_header));
+
 	INIT_LOCK(trampoline_lock);
 }
 
@@ -176,20 +258,23 @@ static struct trampoline_set *alloc_trampolines(char *start, char *end)
 {
 	struct trampoline_set *metadata = calloc(1, sizeof(struct trampoline_set));
 #if _WIN32
-	metadata->buffers = VirtualAlloc(NULL, sizeof(struct trampoline_buffers), MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+	metadata->region = VirtualAlloc(NULL, trampoline_region_size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
 #else
-	metadata->buffers = mmap(NULL, sizeof(struct trampoline_buffers), PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+	metadata->region = mmap(NULL, trampoline_region_size, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
 #endif
-	for (int i=0 ; i<HEADERS_PER_PAGE ; i++)
+	struct block_header *headers_start = REGION_HEADERS_START(metadata);
+	char *rx_buffer_start = REGION_RX_BUFFER_START(metadata);
+	for (int i=0 ; i<trampoline_header_per_page ; i++)
 	{
-		metadata->buffers->headers[i].fnptr = (void(*)(void))invalid;
-		metadata->buffers->headers[i].block = &metadata->buffers->headers[i+1].block;
-		char *block = metadata->buffers->rx_buffer + (i * sizeof(struct block_header));
+		headers_start[i].fnptr = (void(*)(void))invalid;
+		headers_start[i].block = &headers_start[i+1].block;
+		char *block = rx_buffer_start + (i * sizeof(struct block_header));
+
 		memcpy(block, start, end-start);
 	}
-	metadata->buffers->headers[HEADERS_PER_PAGE-1].block = NULL;
-	mprotect(metadata->buffers->rx_buffer, PAGE_SIZE, PROT_READ | PROT_EXEC);
-	clear_cache(metadata->buffers->rx_buffer, &metadata->buffers->rx_buffer[PAGE_SIZE]);
+	headers_start[trampoline_header_per_page-1].block = NULL;
+	mprotect(rx_buffer_start, trampoline_page_size, PROT_READ | PROT_EXEC);
+	clear_cache(rx_buffer_start, rx_buffer_start + trampoline_page_size);
 
 	return metadata;
 }
@@ -208,14 +293,14 @@ IMP imp_implementationWithBlock(id block)
 	if ((b->flags & BLOCK_USE_SRET) == BLOCK_USE_SRET)
 	{
 		setptr = &sret_trampolines;
-		start = &__objc_block_trampoline_sret;
-		end = &__objc_block_trampoline_end_sret;
+		start = trampoline_start_sret;
+		end = trampoline_end_sret;
 	}
 	else
 	{
 		setptr = &trampolines;
-		start = &__objc_block_trampoline;
-		end = &__objc_block_trampoline_end;
+		start = trampoline_start;
+		end = trampoline_end;
 	}
 	size_t trampolineSize = end - start;
 	// If we don't have a trampoline intrinsic for this architecture, return a
@@ -232,14 +317,16 @@ IMP imp_implementationWithBlock(id block)
 		if (set->first_free != -1)
 		{
 			int i = set->first_free;
-			struct block_header *h = &set->buffers->headers[i];
+			struct block_header *headers_start = REGION_HEADERS_START(set);
+			char *rx_buffer_start = REGION_RX_BUFFER_START(set);
+			struct block_header *h = &headers_start[i];
 			struct block_header *next = h->block;
-			set->first_free = next ? (next - set->buffers->headers) : -1;
-			assert(set->first_free < HEADERS_PER_PAGE);
+			set->first_free = next ? (next - headers_start) : -1;
+			assert(set->first_free < trampoline_header_per_page);
 			assert(set->first_free >= -1);
 			h->fnptr = (void(*)(void))b->invoke;
 			h->block = b;
-			uintptr_t addr = (uintptr_t)&set->buffers->rx_buffer[i*sizeof(struct block_header)];
+			uintptr_t addr = (uintptr_t)&rx_buffer_start[i*sizeof(struct block_header)];
 #if (__ARM_ARCH_ISA_THUMB == 2)
 			// If the trampoline is Thumb-2 code, then we must set the low bit
 			// to 1 so that b[l]x instructions put the CPU in the correct mode.
@@ -255,11 +342,13 @@ static int indexForIMP(IMP anIMP, struct trampoline_set **setptr)
 {
 	for (struct trampoline_set *set=*setptr ; set!=NULL ; set=set->next)
 	{
-		if (((char*)anIMP >= set->buffers->rx_buffer) &&
-		    ((char*)anIMP < &set->buffers->rx_buffer[PAGE_SIZE]))
+		struct block_header *headers_start = REGION_HEADERS_START(set);
+		char *rx_buffer_start = REGION_RX_BUFFER_START(set);
+		if (((char *)anIMP >= rx_buffer_start) &&
+		    ((char *)anIMP < &rx_buffer_start[trampoline_page_size]))
 		{
 			*setptr = set;
-			ptrdiff_t offset = (char*)anIMP - set->buffers->rx_buffer;
+			ptrdiff_t offset = (char *)anIMP - rx_buffer_start;
 			return offset / sizeof(struct block_header);
 		}
 	}
@@ -280,7 +369,7 @@ id imp_getBlock(IMP anImp)
 	{
 		return NULL;
 	}
-	return set->buffers->headers[idx].block;
+	return REGION_HEADERS_START(set)[idx].block;
 }
 
 BOOL imp_removeBlock(IMP anImp)
@@ -297,11 +386,12 @@ BOOL imp_removeBlock(IMP anImp)
 	{
 		return NO;
 	}
-	struct block_header *h = &set->buffers->headers[idx];
+	struct block_header *header_start = REGION_HEADERS_START(set);
+	struct block_header *h = &header_start[idx];
 	Block_release(h->block);
 	h->fnptr = (void(*)(void))invalid;
-	h->block = set->first_free == -1 ? NULL : &set->buffers->headers[set->first_free];
-	set->first_free = h - set->buffers->headers;
+	h->block = set->first_free == -1 ? NULL : &header_start[set->first_free];
+	set->first_free = h - header_start;
 	return YES;
 }
 

--- a/block_trampolines.S
+++ b/block_trampolines.S
@@ -161,7 +161,13 @@
 // AArch64 (ARM64) trampoline
 ////////////////////////////////////////////////////////////////////////////////
 .macro trampoline arg0, arg1
-	adr x17, #-4096
+	adr x17, #-0x1000
+	mov \arg1, \arg0
+	ldp \arg0, x17, [x17]
+	br x17
+.endm
+.macro trampoline_16 arg0, arg1
+	adr x17, #-0x4000
 	mov \arg1, \arg0
 	ldp \arg0, x17, [x17]
 	br x17
@@ -215,6 +221,7 @@
 #endif
 
 
+// Trampoline for 4 KiB page size
 .globl CDECL(__objc_block_trampoline)
 CDECL(__objc_block_trampoline):
 	trampoline ARG0, ARG1
@@ -226,6 +233,19 @@ CDECL(__objc_block_trampoline_sret):
 .globl CDECL(__objc_block_trampoline_end_sret)
 CDECL(__objc_block_trampoline_end_sret):
 
+// Trampoline for 16 KiB page sizes
+#if defined(__ARM_ARCH_ISA_A64)
+.globl CDECL(__objc_block_trampoline_16)
+CDECL(__objc_block_trampoline_16):
+	trampoline_16 ARG0, ARG1
+.globl CDECL(__objc_block_trampoline_end_16)
+CDECL(__objc_block_trampoline_end_16):
+.globl CDECL(__objc_block_trampoline_sret_16)
+CDECL(__objc_block_trampoline_sret_16):
+	trampoline_16 SARG0, SARG1
+.globl CDECL(__objc_block_trampoline_end_sret_16)
+CDECL(__objc_block_trampoline_end_sret_16):
+#endif
 
 #ifdef __ELF__
 .section .note.GNU-stack,"",%progbits


### PR DESCRIPTION
This PR adds support for 16 KiB pages on AArch64. `libobjc2` was also broken on Asahi Linux because of this. Additionally, starting November 1st, 2025, Google requires all applications targeting Android 15+ to support 16 KiB page sizes. 

All hard-coded page sizes in `blocks_to_imp.c` were replaced by one call to `getpagesize()` in the initialization function.
PowerPC CI will probably fail, as the CI is still misconfigured and reports 4 KiB pages.