### PR TITLE
CI: Disable FreeBSD Snap

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,8 +3,6 @@ libcxxrt_freebsd_task:
   - freebsd_instance:
      image_family: freebsd-13-5
   - freebsd_instance:
-     image_family: freebsd-15-0-snap
-  - freebsd_instance:
      image_family: freebsd-14-2
 
   install_script: pkg install -y cmake ninja git


### PR DESCRIPTION
Cirrus CI complaints about insufficient compute credits and suspends execution of the CI run indefinitely.