### PR TITLE
[build] Require C++17 as minimal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ message(STATUS "Architecture as detected by CMake: ${CMAKE_SYSTEM_PROCESSOR}")
 # Build configuration
 add_compile_definitions(GNUSTEP __OBJC_RUNTIME_INTERNAL__=1 __OBJC_BOOL)
 
-set(CMAKE_CXX_STANDARD 17)
+
 
 set(libobjc_ASM_SRCS 
 	objc_msgSend.S)
@@ -257,6 +257,7 @@ endif ()
 
 add_library(objc SHARED ${libobjc_C_SRCS} ${libobjc_ASM_SRCS} ${libobjc_OBJC_SRCS} ${libobjc_OBJCXX_SRCS} ${libobjc_ASM_OBJS})
 target_compile_options(objc PRIVATE "$<$<OR:$<COMPILE_LANGUAGE:OBJC>,$<COMPILE_LANGUAGE:OBJCXX>>:-Wno-gnu-folding-constant;-Wno-deprecated-objc-isa-usage;-Wno-objc-root-class;-fobjc-runtime=gnustep-2.0>$<$<COMPILE_LANGUAGE:C>:-Xclang;-fexceptions;-Wno-gnu-folding-constant>")
+target_compile_features(objc PRIVATE cxx_std_17)
 
 list(APPEND libobjc_CXX_SRCS ${libobjcxx_CXX_SRCS})
 target_sources(objc PRIVATE ${libobjc_CXX_SRCS})


### PR DESCRIPTION
Hello!

When building libobjc2 on the Pull Request https://github.com/conan-io/conan-center-index/pull/27957/, it's possible to see that the project is locked to use C++17 always, and does not allow using newer C++ standards like C++20 or C++23.

This PR replaces the locked `CMAKE_CXX_STANDARD` with `target_compile_features`, so C++17 is still required as minimal.

I can build libobjc2 with C++23 without problems:

```
libobjc2/2.2.1: RUN: cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/root/.conan2/p/b/libobdcfe16e9cf751/p" -DGNUSTEP_INSTALL_TYPE="NONE" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/root/.conan2/p/b/libobdcfe16e9cf751/b/src" --loglevel=VERBOSE
-- Using Conan toolchain: /root/.conan2/p/b/libobdcfe16e9cf751/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libstdc++
-- Conan toolchain: C++ Standard 23 with extensions OFF
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The C compiler identification is Clang 17.0.6
-- The ASM compiler identification is Clang with GNU-like command-line
-- Found assembler: /usr/bin/clang-17
-- The CXX compiler identification is Clang 17.0.6
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/clang-17 - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/clang++-17 - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- The OBJC compiler identification is Clang 17.0.6
-- The OBJCXX compiler identification is Clang 17.0.6
-- Detecting OBJC compiler ABI info
-- Detecting OBJC compiler ABI info - done
-- Check for working OBJC compiler: /usr/bin/clang-17 - skipped
-- Detecting OBJCXX compiler ABI info
-- Detecting OBJCXX compiler ABI info - done
-- Check for working OBJCXX compiler: /usr/bin/clang++-17 - skipped
-- Architecture: x86_64
-- Conan: Component target declared 'tsl::robin_map'
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- GNUstep install type set to NONE
-- Performing Test CXA_ALLOCATE_EXCEPTION_NOEXCEPT_COMPILES
-- Performing Test CXA_ALLOCATE_EXCEPTION_NOEXCEPT_COMPILES - Success
-- Configuring done (1.4s)
-- Generating done (0.0s)
-- Build files have been written to: /root/.conan2/p/b/libobdcfe16e9cf751/b/build/Release

libobjc2/2.2.1: Running CMake.build()
libobjc2/2.2.1: RUN: cmake --build "/root/.conan2/p/b/libobdcfe16e9cf751/b/build/Release" --verbose -- -j12
Change Dir: '/root/.conan2/p/b/libobdcfe16e9cf751/b/build/Release'

Run Build Command(s): /usr/bin/ninja -v -j12
[1/35] cd /root/.conan2/p/b/libobdcfe16e9cf751/b/build/Release && /usr/bin/clang++-17 -m64 -stdlib=libstdc++ -fPIC -S /root/.conan2/p/b/libobdcfe16e9cf751/b/src/eh_trampoline.cc -o - -fexceptions -fno-inline | sed s/__gxx_personality_v0/test_eh_personality/g > /root/.conan2/p/b/libobdcfe16e9cf751/b/build/Release/eh_trampoline.S
[2/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/caps.c.o -MF CMakeFiles/objc.dir/caps.c.o.d -o CMakeFiles/objc.dir/caps.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/caps.c
[3/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/hooks.c.o -MF CMakeFiles/objc.dir/hooks.c.o.d -o CMakeFiles/objc.dir/hooks.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/hooks.c
[4/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -x objective-c -O3 -DNDEBUG -std=gnu17 -fPIC -Wno-deprecated-objc-isa-usage -Wno-objc-root-class -fobjc-runtime=gnustep-2.0 -MD -MT CMakeFiles/objc.dir/mutation.m.o -MF CMakeFiles/objc.dir/mutation.m.o.d -o CMakeFiles/objc.dir/mutation.m.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/mutation.m
[5/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/gc_none.c.o -MF CMakeFiles/objc.dir/gc_none.c.o.d -o CMakeFiles/objc.dir/gc_none.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/gc_none.c
[6/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/ivar.c.o -MF CMakeFiles/objc.dir/ivar.c.o.d -o CMakeFiles/objc.dir/ivar.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/ivar.c
[7/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/category_loader.c.o -MF CMakeFiles/objc.dir/category_loader.c.o.d -o CMakeFiles/objc.dir/category_loader.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/category_loader.c
In file included from /root/.conan2/p/b/libobdcfe16e9cf751/b/src/category_loader.c:5:
In file included from /root/.conan2/p/b/libobdcfe16e9cf751/b/src/dtable.h:3:
/root/.conan2/p/b/libobdcfe16e9cf751/b/src/sarray2.h:55:8: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   55 |         void *data[data_size];
      |               ^
1 warning generated.
[8/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/loader.c.o -MF CMakeFiles/objc.dir/loader.c.o.d -o CMakeFiles/objc.dir/loader.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/loader.c
[9/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/block_to_imp.c.o -MF CMakeFiles/objc.dir/block_to_imp.c.o.d -o CMakeFiles/objc.dir/block_to_imp.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/block_to_imp.c
[10/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -x objective-c -O3 -DNDEBUG -std=gnu17 -fPIC -Wno-deprecated-objc-isa-usage -Wno-objc-root-class -fobjc-runtime=gnustep-2.0 -MD -MT CMakeFiles/objc.dir/fast_paths.m.o -MF CMakeFiles/objc.dir/fast_paths.m.o.d -o CMakeFiles/objc.dir/fast_paths.m.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/fast_paths.m
[11/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/alias_table.c.o -MF CMakeFiles/objc.dir/alias_table.c.o.d -o CMakeFiles/objc.dir/alias_table.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/alias_table.c
[12/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/abi_version.c.o -MF CMakeFiles/objc.dir/abi_version.c.o.d -o CMakeFiles/objc.dir/abi_version.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/abi_version.c
[13/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/sarray2.c.o -MF CMakeFiles/objc.dir/sarray2.c.o.d -o CMakeFiles/objc.dir/sarray2.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/sarray2.c
In file included from /root/.conan2/p/b/libobdcfe16e9cf751/b/src/sarray2.c:6:
/root/.conan2/p/b/libobdcfe16e9cf751/b/src/sarray2.h:55:8: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   55 |         void *data[data_size];
      |               ^
1 warning generated.
[14/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/encoding2.c.o -MF CMakeFiles/objc.dir/encoding2.c.o.d -o CMakeFiles/objc.dir/encoding2.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/encoding2.c
[15/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/statics_loader.c.o -MF CMakeFiles/objc.dir/statics_loader.c.o.d -o CMakeFiles/objc.dir/statics_loader.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/statics_loader.c
[16/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -O3 -DNDEBUG -fPIC -MD -MT CMakeFiles/objc.dir/block_trampolines.S.o -MF CMakeFiles/objc.dir/block_trampolines.S.o.d -o CMakeFiles/objc.dir/block_trampolines.S.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/block_trampolines.S
[17/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/sendmsg2.c.o -MF CMakeFiles/objc.dir/sendmsg2.c.o.d -o CMakeFiles/objc.dir/sendmsg2.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/sendmsg2.c
In file included from /root/.conan2/p/b/libobdcfe16e9cf751/b/src/sendmsg2.c:3:
In file included from /root/.conan2/p/b/libobdcfe16e9cf751/b/src/dtable.h:3:
/root/.conan2/p/b/libobdcfe16e9cf751/b/src/sarray2.h:55:8: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   55 |         void *data[data_size];
      |               ^
1 warning generated.
[18/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -O3 -DNDEBUG -fPIC -MD -MT CMakeFiles/objc.dir/eh_trampoline.S.o -MF CMakeFiles/objc.dir/eh_trampoline.S.o.d -o CMakeFiles/objc.dir/eh_trampoline.S.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/build/Release/eh_trampoline.S
[19/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/legacy.c.o -MF CMakeFiles/objc.dir/legacy.c.o.d -o CMakeFiles/objc.dir/legacy.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/legacy.c
[20/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -O3 -DNDEBUG -fPIC -MD -MT CMakeFiles/objc.dir/objc_msgSend.S.o -MF CMakeFiles/objc.dir/objc_msgSend.S.o.d -o CMakeFiles/objc.dir/objc_msgSend.S.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/objc_msgSend.S
[21/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/dtable.c.o -MF CMakeFiles/objc.dir/dtable.c.o.d -o CMakeFiles/objc.dir/dtable.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/dtable.c
In file included from /root/.conan2/p/b/libobdcfe16e9cf751/b/src/dtable.c:8:
/root/.conan2/p/b/libobdcfe16e9cf751/b/src/sarray2.h:55:8: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   55 |         void *data[data_size];
      |               ^
1 warning generated.
[22/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/eh_personality.c.o -MF CMakeFiles/objc.dir/eh_personality.c.o.d -o CMakeFiles/objc.dir/eh_personality.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/eh_personality.c
[23/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -x objective-c -O3 -DNDEBUG -std=gnu17 -fPIC -Wno-deprecated-objc-isa-usage -Wno-objc-root-class -fobjc-runtime=gnustep-2.0 -MD -MT CMakeFiles/objc.dir/Protocol2.m.o -MF CMakeFiles/objc.dir/Protocol2.m.o.d -o CMakeFiles/objc.dir/Protocol2.m.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/Protocol2.m
[24/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -x objective-c -O3 -DNDEBUG -std=gnu17 -fPIC -Wno-deprecated-objc-isa-usage -Wno-objc-root-class -fobjc-runtime=gnustep-2.0 -MD -MT CMakeFiles/objc.dir/NSBlocks.m.o -MF CMakeFiles/objc.dir/NSBlocks.m.o.d -o CMakeFiles/objc.dir/NSBlocks.m.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/NSBlocks.m
In file included from /root/.conan2/p/b/libobdcfe16e9cf751/b/src/NSBlocks.m:6:
In file included from /root/.conan2/p/b/libobdcfe16e9cf751/b/src/dtable.h:3:
/root/.conan2/p/b/libobdcfe16e9cf751/b/src/sarray2.h:55:8: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   55 |         void *data[data_size];
      |               ^
1 warning generated.
[25/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/class_table.c.o -MF CMakeFiles/objc.dir/class_table.c.o.d -o CMakeFiles/objc.dir/class_table.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/class_table.c
In file included from /root/.conan2/p/b/libobdcfe16e9cf751/b/src/class_table.c:9:
In file included from /root/.conan2/p/b/libobdcfe16e9cf751/b/src/dtable.h:3:
/root/.conan2/p/b/libobdcfe16e9cf751/b/src/sarray2.h:55:8: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   55 |         void *data[data_size];
      |               ^
1 warning generated.
[26/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/runtime.c.o -MF CMakeFiles/objc.dir/runtime.c.o.d -o CMakeFiles/objc.dir/runtime.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/runtime.c
In file included from /root/.conan2/p/b/libobdcfe16e9cf751/b/src/runtime.c:8:
In file included from /root/.conan2/p/b/libobdcfe16e9cf751/b/src/dtable.h:3:
/root/.conan2/p/b/libobdcfe16e9cf751/b/src/sarray2.h:55:8: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   55 |         void *data[data_size];
      |               ^
1 warning generated.
[27/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -x objective-c -O3 -DNDEBUG -std=gnu17 -fPIC -Wno-deprecated-objc-isa-usage -Wno-objc-root-class -fobjc-runtime=gnustep-2.0 -MD -MT CMakeFiles/objc.dir/blocks_runtime.m.o -MF CMakeFiles/objc.dir/blocks_runtime.m.o.d -o CMakeFiles/objc.dir/blocks_runtime.m.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/blocks_runtime.m
[28/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -O3 -DNDEBUG -fPIC -Xclang -fexceptions -MD -MT CMakeFiles/objc.dir/protocol.c.o -MF CMakeFiles/objc.dir/protocol.c.o.d -o CMakeFiles/objc.dir/protocol.c.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/protocol.c
[29/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -x objective-c -O3 -DNDEBUG -std=gnu17 -fPIC -Wno-deprecated-objc-isa-usage -Wno-objc-root-class -fobjc-runtime=gnustep-2.0 -MD -MT CMakeFiles/objc.dir/associate.m.o -MF CMakeFiles/objc.dir/associate.m.o.d -o CMakeFiles/objc.dir/associate.m.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/associate.m
In file included from /root/.conan2/p/b/libobdcfe16e9cf751/b/src/associate.m:10:
In file included from /root/.conan2/p/b/libobdcfe16e9cf751/b/src/dtable.h:3:
/root/.conan2/p/b/libobdcfe16e9cf751/b/src/sarray2.h:55:8: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   55 |         void *data[data_size];
      |               ^
1 warning generated.
[30/35] /usr/bin/clang++-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -stdlib=libstdc++ -O3 -DNDEBUG -std=c++23 -fPIC -MD -MT CMakeFiles/objc.dir/objcxx_eh.cc.o -MF CMakeFiles/objc.dir/objcxx_eh.cc.o.d -o CMakeFiles/objc.dir/objcxx_eh.cc.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/objcxx_eh.cc
[31/35] /usr/bin/clang-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -x objective-c -O3 -DNDEBUG -std=gnu17 -fPIC -Wno-deprecated-objc-isa-usage -Wno-objc-root-class -fobjc-runtime=gnustep-2.0 -MD -MT CMakeFiles/objc.dir/properties.m.o -MF CMakeFiles/objc.dir/properties.m.o.d -o CMakeFiles/objc.dir/properties.m.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/properties.m
[32/35] /usr/bin/clang++-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -x objective-c++ -O3 -DNDEBUG -std=c++23 -fPIC -Wno-deprecated-objc-isa-usage -Wno-objc-root-class -fobjc-runtime=gnustep-2.0 -MD -MT CMakeFiles/objc.dir/arc.mm.o -MF CMakeFiles/objc.dir/arc.mm.o.d -o CMakeFiles/objc.dir/arc.mm.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/arc.mm
[33/35] /usr/bin/clang++-17 -DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept -DGNUSTEP -DNO_LEGACY -DNO_SELECTOR_MISMATCH_WARNINGS -DOLDABI_COMPAT=1 -DTYPE_DEPENDENT_DISPATCH -D__OBJC_RUNTIME_INTERNAL__=1 -Dobjc_EXPORTS -isystem /root/.conan2/p/tsl-ra6e09c6f03a15/p/include -m64 -stdlib=libstdc++ -O3 -DNDEBUG -std=c++23 -fPIC -MD -MT CMakeFiles/objc.dir/selector_table.cc.o -MF CMakeFiles/objc.dir/selector_table.cc.o.d -o CMakeFiles/objc.dir/selector_table.cc.o -c /root/.conan2/p/b/libobdcfe16e9cf751/b/src/selector_table.cc
[34/35] : && /usr/bin/clang-17 -fPIC -m64 -O3 -DNDEBUG  -shared -m64 -Xlinker --dependency-file=CMakeFiles/objc.dir/link.d -Wl,-soname,libobjc.so.4.6 -o libobjc.so.4.6 CMakeFiles/objc.dir/alias_table.c.o CMakeFiles/objc.dir/block_to_imp.c.o CMakeFiles/objc.dir/caps.c.o CMakeFiles/objc.dir/category_loader.c.o CMakeFiles/objc.dir/class_table.c.o CMakeFiles/objc.dir/dtable.c.o CMakeFiles/objc.dir/encoding2.c.o CMakeFiles/objc.dir/gc_none.c.o CMakeFiles/objc.dir/hooks.c.o CMakeFiles/objc.dir/ivar.c.o CMakeFiles/objc.dir/loader.c.o CMakeFiles/objc.dir/mutation.m.o CMakeFiles/objc.dir/protocol.c.o CMakeFiles/objc.dir/runtime.c.o CMakeFiles/objc.dir/sarray2.c.o CMakeFiles/objc.dir/sendmsg2.c.o CMakeFiles/objc.dir/fast_paths.m.o CMakeFiles/objc.dir/eh_personality.c.o CMakeFiles/objc.dir/legacy.c.o CMakeFiles/objc.dir/abi_version.c.o CMakeFiles/objc.dir/statics_loader.c.o CMakeFiles/objc.dir/block_trampolines.S.o CMakeFiles/objc.dir/objc_msgSend.S.o CMakeFiles/objc.dir/eh_trampoline.S.o CMakeFiles/objc.dir/NSBlocks.m.o CMakeFiles/objc.dir/Protocol2.m.o CMakeFiles/objc.dir/associate.m.o CMakeFiles/objc.dir/blocks_runtime.m.o CMakeFiles/objc.dir/properties.m.o CMakeFiles/objc.dir/arc.mm.o CMakeFiles/objc.dir/selector_table.cc.o CMakeFiles/objc.dir/objcxx_eh.cc.o  -lm  -lstdc++  -lm  -lstdc++  -lm && :
[35/35] /root/.conan2/p/cmakef735e5048398f/p/bin/cmake -E cmake_symlink_library libobjc.so.4.6 libobjc.so.4.6 libobjc.so && :


libobjc2/2.2.1: Package 'e8facf0c0c10f6416b6b86b19e5ddb49e30f8b60' built
libobjc2/2.2.1: Build folder /root/.conan2/p/b/libobdcfe16e9cf751/b/build/Release
libobjc2/2.2.1: Generating the package
libobjc2/2.2.1: Packaging in folder /root/.conan2/p/b/libobdcfe16e9cf751/p
libobjc2/2.2.1: Calling package()
libobjc2/2.2.1: Running CMake.install()
libobjc2/2.2.1: RUN: cmake --install "/root/.conan2/p/b/libobdcfe16e9cf751/b/build/Release" --prefix "/root/.conan2/p/b/libobdcfe16e9cf751/p" --verbose
-- Install configuration: "Release"
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/lib/libobjc.so.4.6
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/lib/libobjc.so
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/Availability.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/Object.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/Protocol.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/blocks_private.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/blocks_runtime.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/capabilities.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/developer.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/encoding.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/hooks.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/message.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/objc-api.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/objc-arc.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/objc-auto.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/objc-class.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/objc-exception.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/objc-runtime.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/objc-visibility.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/objc.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/runtime-deprecated.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/runtime.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/objc/slot.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/Block.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/include/Block_private.h
-- Installing: /root/.conan2/p/b/libobdcfe16e9cf751/p/lib/pkgconfig/libobjc.pc
```

Regards!