### PR TITLE
Fix declaration of objc_resolve_class

### DIFF
--- a/dtable.c
+++ b/dtable.c
@@ -677,7 +677,7 @@ LEGACY void update_dispatch_table_for_class(Class cls)
 	objc_update_dtable_for_class(cls);
 }
 
-void objc_resolve_class(Class);
+BOOL objc_resolve_class(Class);
 
 __attribute__((unused)) static void objc_release_object_lock(id *x)
 {

--- a/runtime.c
+++ b/runtime.c
@@ -22,7 +22,7 @@
 #define CHECK_ARG(arg) if (0 == arg) { return 0; }
 
 static inline void safe_remove_from_subclass_list(Class cls);
-PRIVATE void objc_resolve_class(Class);
+PRIVATE BOOL objc_resolve_class(Class);
 void objc_send_initialize(id object);
 
 /**


### PR DESCRIPTION
WebAssembly is quite sensitive to mismatches between the declaration and definition of a function. While only producing a warning when compiling, the mismatch will result in a crash at runtime.