### PR TITLE
Update compile options to enable static linking to work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,9 @@ add_compile_definitions($<$<BOOL:${STRICT_APPLE_COMPATIBILITY}>:STRICT_APPLE_COM
 
 configure_file(objc/objc-config.h.in objc/objc-config.h @ONLY)
 include_directories("${PROJECT_BINARY_DIR}/objc/")
+if (IS_DIRECTORY /usr/local/include)                                           
+	include_directories("/usr/local/include")
+endif()
 
 if (EMBEDDED_BLOCKS_RUNTIME)
 	list(APPEND libobjc_ASM_SRCS block_trampolines.S)
@@ -298,7 +301,9 @@ set_property(TARGET PROPERTY NO_SONAME true)
 
 option(BUILD_STATIC_LIBOBJC "Build the static version of libobjc" OFF)
 if (BUILD_STATIC_LIBOBJC)
-	add_library(objc-static STATIC ${libobjc_C_SRCS} ${libobjc_ASM_SRCS} ${libobjc_OBJC_SRCS} ${libobjc_CXX_SRCS})
+	add_library(objc-static STATIC ${libobjc_C_SRCS} ${libobjc_ASM_SRCS} ${libobjc_OBJC_SRCS} ${libobjc_OBJCXX_SRCS} ${libobjc_CXX_SRCS})
+	target_compile_options(objc-static PRIVATE "$<$<OR:$<COMPILE_LANGUAGE:OBJC>,$<COMPILE_LANGUAGE:OBJCXX>>:-Wno-gnu-folding-constant;-Wno-deprecated-objc-isa-usage;-Wno-objc-root-class;-fobjc-runtime=gnustep-2.0>$<$<COMPILE_LANGUAGE:C>:-Xclang;-fexceptions;-Wno-gnu-folding-constant>")
+	target_compile_features(objc-static PRIVATE cxx_std_20)
 	set_target_properties(objc-static PROPERTIES
 		POSITION_INDEPENDENT_CODE true
 		OUTPUT_NAME ${LIBOBJC_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,9 +155,6 @@ add_compile_definitions($<$<BOOL:${STRICT_APPLE_COMPATIBILITY}>:STRICT_APPLE_COM
 
 configure_file(objc/objc-config.h.in objc/objc-config.h @ONLY)
 include_directories("${PROJECT_BINARY_DIR}/objc/")
-if (IS_DIRECTORY /usr/local/include)                                           
-	include_directories("/usr/local/include")
-endif()
 
 if (EMBEDDED_BLOCKS_RUNTIME)
 	list(APPEND libobjc_ASM_SRCS block_trampolines.S)
@@ -304,6 +301,7 @@ if (BUILD_STATIC_LIBOBJC)
 	add_library(objc-static STATIC ${libobjc_C_SRCS} ${libobjc_ASM_SRCS} ${libobjc_OBJC_SRCS} ${libobjc_OBJCXX_SRCS} ${libobjc_CXX_SRCS})
 	target_compile_options(objc-static PRIVATE "$<$<OR:$<COMPILE_LANGUAGE:OBJC>,$<COMPILE_LANGUAGE:OBJCXX>>:-Wno-gnu-folding-constant;-Wno-deprecated-objc-isa-usage;-Wno-objc-root-class;-fobjc-runtime=gnustep-2.0>$<$<COMPILE_LANGUAGE:C>:-Xclang;-fexceptions;-Wno-gnu-folding-constant>")
 	target_compile_features(objc-static PRIVATE cxx_std_20)
+	target_link_libraries(objc-static PRIVATE tsl::robin_map)
 	set_target_properties(objc-static PROPERTIES
 		POSITION_INDEPENDENT_CODE true
 		OUTPUT_NAME ${LIBOBJC_NAME})

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -117,7 +117,7 @@ set_target_properties(test_runtime PROPERTIES
 
 # Function for adding a test.  This takes the name of the test and the list of
 # source files as arguments.
-function(addtest_flags TEST_NAME FLAGS TEST_SOURCE)
+function(addtest_flags TEST_NAME FLAGS TEST_SOURCE LINK_TARGET)
 	if (${TEST_NAME} MATCHES ".*_arc")
 		# Only compile the main file with ARC
 		set_source_files_properties(${TEST_SOURCE}
@@ -139,21 +139,28 @@ function(addtest_flags TEST_NAME FLAGS TEST_SOURCE)
 	if(WIN32)
 		set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT_MODIFICATION "PATH=path_list_append:${CMAKE_BINARY_DIR}")
 	endif()
-	target_link_libraries(${TEST_NAME} objc)
+	target_link_libraries(${TEST_NAME} ${LINK_TARGET})
 endfunction(addtest_flags)
 
-function(addtest_variants TEST TEST_SOURCE LEGACY)
-	addtest_flags(${TEST} "-O0 -fobjc-runtime=gnustep-2.2 -UNDEBUG -DGS_RUNTIME_V2" "${TEST_SOURCE}")
-	target_sources(${TEST} PRIVATE $<TARGET_OBJECTS:test_runtime>)
-	addtest_flags("${TEST}_optimised" "-O3 -fobjc-runtime=gnustep-2.2 -UNDEBUG -DGS_RUNTIME_V2" "${TEST_SOURCE}")
-	target_sources("${TEST}_optimised" PRIVATE $<TARGET_OBJECTS:test_runtime>)
+function(addtest_variants_for_target TEST TEST_SOURCE LEGACY LINK_TARGET SUFFIX)
+	addtest_flags("${TEST}${SUFFIX}" "-O0 -fobjc-runtime=gnustep-2.2 -UNDEBUG -DGS_RUNTIME_V2" "${TEST_SOURCE}" ${LINK_TARGET})
+	target_sources("${TEST}${SUFFIX}" PRIVATE $<TARGET_OBJECTS:test_runtime>)
+	addtest_flags("${TEST}_optimised${SUFFIX}" "-O3 -fobjc-runtime=gnustep-2.2 -UNDEBUG -DGS_RUNTIME_V2" "${TEST_SOURCE}" ${LINK_TARGET})
+	target_sources("${TEST}_optimised${SUFFIX}" PRIVATE $<TARGET_OBJECTS:test_runtime>)
 
 	# -fobjc-arc is not supported on platforms using the legacy runtime
 	if (${LEGACY} AND ${OLDABI_COMPAT} AND NOT ${TEST} MATCHES ".*_arc")
-		addtest_flags("${TEST}_legacy" "-O0 -fobjc-runtime=gnustep-1.7 -UNDEBUG" "${TEST_SOURCE}")
-		target_sources("${TEST}_legacy" PRIVATE $<TARGET_OBJECTS:test_runtime_legacy>)
-		addtest_flags("${TEST}_legacy_optimised" "-O3 -fobjc-runtime=gnustep-1.7 -UNDEBUG" "${TEST_SOURCE}")
-		target_sources("${TEST}_legacy_optimised" PRIVATE $<TARGET_OBJECTS:test_runtime_legacy>)
+		addtest_flags("${TEST}_legacy${SUFFIX}" "-O0 -fobjc-runtime=gnustep-1.7 -UNDEBUG" "${TEST_SOURCE}" ${LINK_TARGET})
+		target_sources("${TEST}_legacy${SUFFIX}" PRIVATE $<TARGET_OBJECTS:test_runtime_legacy>)
+		addtest_flags("${TEST}_legacy_optimised${SUFFIX}" "-O3 -fobjc-runtime=gnustep-1.7 -UNDEBUG" "${TEST_SOURCE}" ${LINK_TARGET})
+		target_sources("${TEST}_legacy_optimised${SUFFIX}" PRIVATE $<TARGET_OBJECTS:test_runtime_legacy>)
+	endif()
+endfunction(addtest_variants_for_target)
+
+function(addtest_variants TEST TEST_SOURCE LEGACY)
+	addtest_variants_for_target(${TEST} "${TEST_SOURCE}" ${LEGACY} objc "")
+	if (BUILD_STATIC_LIBOBJC)
+		addtest_variants_for_target(${TEST} "${TEST_SOURCE}" false objc-static "_static")
 	endif()
 endfunction(addtest_variants)
 
@@ -189,4 +196,8 @@ set_tests_properties(ManyManySelectors_optimised PROPERTIES PROCESSORS 3)
 if (${LEGACY})
 	set_tests_properties(ManyManySelectors_legacy PROPERTIES PROCESSORS 3)
 	set_tests_properties(ManyManySelectors_legacy_optimised PROPERTIES PROCESSORS 3)
+endif ()
+if (BUILD_STATIC_LIBOBJC)
+	set_tests_properties(ManyManySelectors_static PROPERTIES PROCESSORS 3)
+	set_tests_properties(ManyManySelectors_optimised_static PROPERTIES PROCESSORS 3)
 endif ()

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -117,7 +117,7 @@ set_target_properties(test_runtime PROPERTIES
 
 # Function for adding a test.  This takes the name of the test and the list of
 # source files as arguments.
-function(addtest_flags TEST_NAME FLAGS TEST_SOURCE LINK_TARGET)
+function(addtest_flags TEST_NAME FLAGS TEST_SOURCE LINK_TARGET EXTRA_LINK_FLAGS)
 	if (${TEST_NAME} MATCHES ".*_arc")
 		# Only compile the main file with ARC
 		set_source_files_properties(${TEST_SOURCE}
@@ -129,7 +129,7 @@ function(addtest_flags TEST_NAME FLAGS TEST_SOURCE LINK_TARGET)
 	set_target_properties(${TEST_NAME} PROPERTIES
 		INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR};${PROJECT_BINARY_DIR}/objc/"
 		COMPILE_FLAGS "-Xclang -fblocks -Xclang -fobjc-exceptions ${FLAGS}"
-		LINK_FLAGS ${INCREMENTAL}
+		LINK_FLAGS "${INCREMENTAL} ${EXTRA_LINK_FLAGS}"
 		LINKER_LANGUAGE C
 	)
 	set_property(TEST ${TEST_NAME} PROPERTY SKIP_RETURN_CODE 77)
@@ -142,25 +142,25 @@ function(addtest_flags TEST_NAME FLAGS TEST_SOURCE LINK_TARGET)
 	target_link_libraries(${TEST_NAME} ${LINK_TARGET})
 endfunction(addtest_flags)
 
-function(addtest_variants_for_target TEST TEST_SOURCE LEGACY LINK_TARGET SUFFIX)
-	addtest_flags("${TEST}${SUFFIX}" "-O0 -fobjc-runtime=gnustep-2.2 -UNDEBUG -DGS_RUNTIME_V2" "${TEST_SOURCE}" ${LINK_TARGET})
+function(addtest_variants_for_target TEST TEST_SOURCE LEGACY LINK_TARGET SUFFIX EXTRA_LINK_FLAGS)
+	addtest_flags("${TEST}${SUFFIX}" "-O0 -fobjc-runtime=gnustep-2.2 -UNDEBUG -DGS_RUNTIME_V2" "${TEST_SOURCE}" ${LINK_TARGET} "${EXTRA_LINK_FLAGS}")
 	target_sources("${TEST}${SUFFIX}" PRIVATE $<TARGET_OBJECTS:test_runtime>)
-	addtest_flags("${TEST}_optimised${SUFFIX}" "-O3 -fobjc-runtime=gnustep-2.2 -UNDEBUG -DGS_RUNTIME_V2" "${TEST_SOURCE}" ${LINK_TARGET})
+	addtest_flags("${TEST}_optimised${SUFFIX}" "-O3 -fobjc-runtime=gnustep-2.2 -UNDEBUG -DGS_RUNTIME_V2" "${TEST_SOURCE}" ${LINK_TARGET} "${EXTRA_LINK_FLAGS}")
 	target_sources("${TEST}_optimised${SUFFIX}" PRIVATE $<TARGET_OBJECTS:test_runtime>)
 
 	# -fobjc-arc is not supported on platforms using the legacy runtime
 	if (${LEGACY} AND ${OLDABI_COMPAT} AND NOT ${TEST} MATCHES ".*_arc")
-		addtest_flags("${TEST}_legacy${SUFFIX}" "-O0 -fobjc-runtime=gnustep-1.7 -UNDEBUG" "${TEST_SOURCE}" ${LINK_TARGET})
+		addtest_flags("${TEST}_legacy${SUFFIX}" "-O0 -fobjc-runtime=gnustep-1.7 -UNDEBUG" "${TEST_SOURCE}" ${LINK_TARGET} "${EXTRA_LINK_FLAGS}")
 		target_sources("${TEST}_legacy${SUFFIX}" PRIVATE $<TARGET_OBJECTS:test_runtime_legacy>)
-		addtest_flags("${TEST}_legacy_optimised${SUFFIX}" "-O3 -fobjc-runtime=gnustep-1.7 -UNDEBUG" "${TEST_SOURCE}" ${LINK_TARGET})
+		addtest_flags("${TEST}_legacy_optimised${SUFFIX}" "-O3 -fobjc-runtime=gnustep-1.7 -UNDEBUG" "${TEST_SOURCE}" ${LINK_TARGET} "${EXTRA_LINK_FLAGS}")
 		target_sources("${TEST}_legacy_optimised${SUFFIX}" PRIVATE $<TARGET_OBJECTS:test_runtime_legacy>)
 	endif()
 endfunction(addtest_variants_for_target)
 
 function(addtest_variants TEST TEST_SOURCE LEGACY)
-	addtest_variants_for_target(${TEST} "${TEST_SOURCE}" ${LEGACY} objc "")
+	addtest_variants_for_target(${TEST} "${TEST_SOURCE}" ${LEGACY} objc "" "")
 	if (BUILD_STATIC_LIBOBJC)
-		addtest_variants_for_target(${TEST} "${TEST_SOURCE}" false objc-static "_static")
+		addtest_variants_for_target(${TEST} "${TEST_SOURCE}" false objc-static "_static" "-static")
 	endif()
 endfunction(addtest_variants)
 


### PR DESCRIPTION
This makes the static options the same as the dynamic, which was causing the linking to fail. As this requires robin-map, and this is installed under /usr/local on BSD and similar systems, then we also add /usr/local/include to the header search path if it exists.

All the tests pass, and this works perfectly with my test code too.