### PR TITLE
Fix imp_getBlock/imp_removeBlock for struct-return block IMPs

### DIFF
--- a/Test/BlockImpTest.m
+++ b/Test/BlockImpTest.m
@@ -50,8 +50,11 @@ int main(void)
 		struct big b = {1, 2, 3, 4, 5};
 		return b;
 	};
+	blk = Block_copy((blk));
 	imp = imp_implementationWithBlock(blk);
 	assert(imp && "Can't make sret IMP");
+	// imp_getBlock / imp_removeBlock must also work for struct-return blocks.
+	assert(imp_getBlock(imp) == blk);
 	type = block_copyIMPTypeEncoding_np(blk);
 	assert(NULL != type);
 	class_addMethod((objc_getMetaClass("Foo")), @selector(sret), imp, type);
@@ -62,5 +65,7 @@ int main(void)
 	assert(s.c == 3);
 	assert(s.d == 4);
 	assert(s.e == 5);
+	imp_removeBlock(imp);
+	assert(imp_getBlock(imp) != blk);
 	return 0;
 }

--- a/block_to_imp.c
+++ b/block_to_imp.c
@@ -373,7 +373,7 @@ id imp_getBlock(IMP anImp)
 	if (idx == -1)
 	{
 		set = sret_trampolines;
-		indexForIMP(anImp, &set);
+		idx = indexForIMP(anImp, &set);
 	}
 	if (idx == -1)
 	{
@@ -390,7 +390,7 @@ BOOL imp_removeBlock(IMP anImp)
 	if (idx == -1)
 	{
 		set = sret_trampolines;
-		indexForIMP(anImp, &set);
+		idx = indexForIMP(anImp, &set);
 	}
 	if (idx == -1)
 	{


### PR DESCRIPTION
## Summary

`imp_getBlock` and `imp_removeBlock` first look the IMP up in the regular
trampoline set; if that misses, they fall back to `sret_trampolines`. But the
fallback **discarded the result** of the second `indexForIMP()` call, leaving
`idx` at `-1`:

```c
int idx = indexForIMP(anImp, &set);
if (idx == -1)
{
    set = sret_trampolines;
    indexForIMP(anImp, &set);   // result thrown away; idx stays -1
}
if (idx == -1) { return NULL; } // ... so struct-return IMPs always land here
```

As a result `imp_getBlock` always returned `NULL` for a struct-return (sret)
block IMP, and `imp_removeBlock` returned `NO` without releasing the block —
leaking the block and its trampoline slot.

## Fix

Assign the fallback `indexForIMP()` result to `idx` in both functions.

## Reproduction / test

`Test/BlockImpTest.m` already creates an sret block IMP (the `struct big`
block) but only checked `imp_getBlock`/`imp_removeBlock` on the non-sret IMP.
Before the fix, asserting `imp_getBlock(imp) == blk` on the sret IMP fails
(returns `NULL`); after, it passes. The test now exercises both functions on
the struct-return IMP (all four BlockImpTest variants pass).
