### PR TITLE
Fix lock-order inversion between the runtime lock and the selector table lock

### DIFF
--- a/selector_table.cc
+++ b/selector_table.cc
@@ -447,6 +447,15 @@ extern "C" PRIVATE SEL objc_register_selector(SEL aSel)
 		return registered;
 	}
 	assert(!(aSel->types && (strstr(aSel->types, "@\"") != nullptr)));
+	// Acquire the runtime lock before the selector table lock.  Registering a
+	// new selector resizes the dtables (objc_resize_dtables), which takes the
+	// runtime lock, while the class loader (__objc_load) takes the runtime lock
+	// first and then registers selectors.  Acquiring the two in a consistent
+	// runtime-before-table order avoids a lock-order inversion
+	// (gnustep/libobjc2#391).  Holding the runtime lock for the whole
+	// registration also keeps the new selector's index (the selector_list size)
+	// and the matching dtable resize atomic with respect to other resizes.
+	LOCK_RUNTIME_FOR_SCOPE();
 	LockGuard g{selector_table_lock};
 	register_selector_locked(aSel);
 	return aSel;
@@ -463,6 +472,9 @@ SEL objc_register_selector_copy(UnregisteredSelector &aSel, BOOL copyArgs)
 	{
 		return copy;
 	}
+	// Runtime lock before the selector table lock, for the duration of the
+	// registration; see objc_register_selector above and gnustep/libobjc2#391.
+	LOCK_RUNTIME_FOR_SCOPE();
 	LockGuard g{selector_table_lock};
 	copy = selector_lookup(aSel.name, aSel.types);
 	if (nullptr != copy && selector_identical(aSel, copy))


### PR DESCRIPTION
Fixes #391.

Registering a new selector resizes the dtables, and `objc_resize_dtables` takes the runtime lock (`dtable.c:618`) while the selector table lock is already held (`objc_register_selector_copy` → `register_selector_locked`). The class loader does the opposite — `__objc_load` holds the runtime lock (`loader.c:186`) and then registers selectors, taking the selector table lock (`loader.c:217` → `selector_lookup`). That's the `runtime_mutex` ⇄ `selector_table_lock` cycle, reachable when a concurrent `dlopen` of an Objective-C module races a selector registration that triggers a dtable resize.

This holds the runtime lock for the duration of registration, acquiring it **before** the selector table lock in both registration entry points, so every path takes the two locks in the same `runtime → selector` order. It also keeps the new selector's index (the `selector_list` size) and the matching dtable resize atomic with respect to other resizes, which registration relies on. The runtime lock is recursive, so the nested acquisition inside `objc_resize_dtables` is unaffected, and the already-registered fast paths still take neither lock.

### On the dedicated-lock idea from #391

I started down the "new lock that protects dtable resizes" path, but `objc_resize_dtables` walks the class table (`class_table_next`), and `class_table_insert` / `class_table_next` have no locking of their own — they rely on the caller holding the runtime lock. So a resize can't move off the runtime lock without also moving all class-table protection onto the new lock, which cascades into decomposing the big runtime lock more broadly (the audit you mentioned). The lock that protects dtable resizes today *is* the runtime lock; this change does the minimal version of that suggestion — hold it for the duration of registration — using the lock that already guards the resize. Happy to pursue the finer-grained decomposition separately if you'd prefer.

### Validation

- **TSan**, selector-stress harness (concurrent `sel_registerName` + class load at startup): clean master reports the inversion deterministically (2 reports); with this change, **0**. Harness runs to completion both ways.
- **Functional**: full `ctest` suite **194/194 pass**, including `ManyManySelectors`.

The remaining TSan data races on the `selector_list` size are a separate, pre-existing unsynchronized-read finding and are not addressed here.
