### PR TITLE
Skip type qualifiers before selecting the nil return slot

### DIFF
--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -43,6 +43,7 @@ set(TESTS
 	IVarOverlap.m
 	IVarSuperclassOverlap.m
 	objc_msgSend.m
+	NilTypeQualifier.m
 	msgInterpose.m
 	NilException.m
 	MethodArguments.m

--- a/Test/NilTypeQualifier.m
+++ b/Test/NilTypeQualifier.m
@@ -1,0 +1,64 @@
+#include "Test.h"
+#include "../objc/slot.h"
+#include <assert.h>
+
+@interface QualReturn : Test
+- (double)d;
+- (bycopy double)bcd;
+- (float)f;
+- (bycopy float)bcf;
+@end
+@implementation QualReturn
+- (double)d { return 1.0; }
+- (bycopy double)bcd { return 1.0; }
+- (float)f { return 1.0f; }
+- (bycopy float)bcf { return 1.0f; }
+@end
+
+/* The nil-receiver fast paths in the runtime lookup functions pick a zero slot
+ * from the method's return type, so a message to nil returns a correctly typed
+ * zero.  The return type is read after skipping any type qualifiers (bycopy,
+ * oneway, ...).  A qualifier-prefixed floating-point return (e.g. bycopy
+ * double, encoded "Od...") must map to the same zero slot as the plain
+ * floating-point return; otherwise nil gets an integer zero slot and the
+ * floating-point result is undefined.
+ */
+
+static IMP nilSlotSender(SEL sel)
+{
+	id nilObj = nil;
+	return objc_msg_lookup_sender(&nilObj, sel, nil)->method;
+}
+
+static IMP nilSlotLookup2(SEL sel)
+{
+	id nilObj = nil;
+	return objc_msg_lookup2(&nilObj, sel);
+}
+
+int main(void)
+{
+	Class cls = [QualReturn class];
+	Method mD   = class_getInstanceMethod(cls, @selector(d));
+	Method mBcD = class_getInstanceMethod(cls, @selector(bcd));
+	Method mF   = class_getInstanceMethod(cls, @selector(f));
+	Method mBcF = class_getInstanceMethod(cls, @selector(bcf));
+	SEL d   = method_getName(mD);
+	SEL bcd = method_getName(mBcD);
+	SEL f   = method_getName(mF);
+	SEL bcf = method_getName(mBcF);
+
+	/* Premise: the bycopy qualifier prefixes the encoding, so the return type
+	 * character is not at offset 0. */
+	assert('O' == method_getTypeEncoding(mBcD)[0]);
+	assert('O' == method_getTypeEncoding(mBcF)[0]);
+
+	/* A qualifier-prefixed floating-point return must select the same nil slot
+	 * as the unqualified one. */
+	assert(nilSlotSender(bcd) == nilSlotSender(d));
+	assert(nilSlotSender(bcf) == nilSlotSender(f));
+	assert(nilSlotLookup2(bcd) == nilSlotLookup2(d));
+	assert(nilSlotLookup2(bcf) == nilSlotLookup2(f));
+
+	return 0;
+}

--- a/sendmsg2.c
+++ b/sendmsg2.c
@@ -189,7 +189,7 @@ struct objc_slot *objc_msg_lookup_sender(id *receiver, SEL selector, id sender)
 			{
 				t++;
 			}
-			switch (selector->types[0])
+			switch (*t)
 			{
 				case 'D': return &nil_slot_D_v1;
 				case 'd': return &nil_slot_d_v1;
@@ -225,7 +225,7 @@ static struct objc_slot2* objc_slot_lookup(id *receiver, SEL selector)
 			{
 				t++;
 			}
-			switch (selector->types[0])
+			switch (*t)
 			{
 				case 'D': return (struct objc_slot2*)&nil_slot_D;
 				case 'd': return (struct objc_slot2*)&nil_slot_d;
@@ -261,7 +261,7 @@ struct objc_slot2 *objc_slot_lookup_version(id *receiver, SEL selector, uint64_t
 			{
 				t++;
 			}
-			switch (selector->types[0])
+			switch (*t)
 			{
 				case 'D': return (struct objc_slot2*)&nil_slot_D;
 				case 'd': return (struct objc_slot2*)&nil_slot_d;


### PR DESCRIPTION
Closes #396.

The nil-receiver fast paths in objc_msg_lookup_sender, objc_slot_lookup and
objc_slot_lookup_version skip type qualifiers into `t` but then switch on
`selector->types[0]`, the unskipped encoding.  A qualifier-prefixed
floating-point return (for example `bycopy double`, encoded "Od...") falls
through to the integer nil slot, so a message to nil returns an undefined
floating-point value.  Switching on `*t` uses the skipped encoding, as
suggested in #396.

Test/NilTypeQualifier.m checks that a qualifier-prefixed double and float
return select the same nil slot as the unqualified return, through both
objc_msg_lookup_sender and objc_msg_lookup2.  It fails before this change and
passes after; the full suite passes (198/198).


