### PR TITLE
CI: find vcvarsall.bat with vswhere

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,16 +158,25 @@ jobs:
             flags: -m32
           - arch: x64
             flags: -m64
-          - vspath: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build
       # Don't abort runners if a single one fails
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.build-type }} ${{ matrix.arch }}
     steps:
-    - name: look at VS install
-      shell: cmd
+    # The runner image carries whichever Visual Studio it was built with, so
+    # ask the installer where the C++ tools are rather than naming a version.
+    - name: Find vcvarsall.bat
+      shell: pwsh
       run: |
-        dir "${{ matrix.vspath }}"
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        $install = & $vswhere -latest -products * `
+          -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+          -property installationPath
+        if (!$install) { throw "no Visual Studio with the C++ tools installed" }
+        $vcvarsall = "$install\VC\Auxiliary\Build\vcvarsall.bat"
+        if (!(Test-Path $vcvarsall)) { throw "$vcvarsall does not exist" }
+        echo "using $vcvarsall"
+        echo "VCVARSALL=$vcvarsall" >> $env:GITHUB_ENV
     - uses: actions/checkout@v3
       with:
         submodules: true
@@ -177,7 +186,7 @@ jobs:
     - name: Configure CMake
       shell: cmd
       run: |
-        call "${{ matrix.vspath }}\vcvarsall.bat" ${{ matrix.arch }}
+        call "%VCVARSALL%" ${{ matrix.arch }}
         set CFLAGS=${{ matrix.flags }}
         set CXXFLAGS=${{ matrix.flags }}
         set OBJCFLAGS=${{ matrix.flags }}
@@ -190,7 +199,7 @@ jobs:
       shell: cmd
       working-directory: build
       run: |
-        call "${{ matrix.vspath }}\vcvarsall.bat" ${{ matrix.arch }}
+        call "%VCVARSALL%" ${{ matrix.arch }}
         ninja
     - name: Test
       shell: cmd


### PR DESCRIPTION
The windows jobs have failed since the runner image moved to Visual
Studio 2026. The matrix names C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build,
and the first step's dir on that path reports "The system cannot find the path
specified", so the job stops before checkout. The same jobs fail the same way
on master.

The install on windows-2025 is now under C:\Program Files\Microsoft Visual
Studio\18\Enterprise. Rather than name that path, the first step asks vswhere
for the latest installation carrying the C++ tools and writes its vcvarsall.bat
to the environment; Configure CMake and Build call it from there. vswhere sits
at a fixed location under Program Files (x86) on every Windows runner image.
The step stops with a message if there is no such installation, or if
vcvarsall.bat is not where it says.

Verified on a run of this branch: every windows job found the install under
C:\Program Files\Microsoft Visual Studio\18\Enterprise, configured, built,
and passed 106 of 106 tests.
