### PR TITLE
CI: check out and cache with Node 24 actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.build-type }} LLVM-${{ matrix.llvm-version }} ${{ matrix.cxxlib }} BlocksRuntime-${{ matrix.blocks-runtime }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Install dependencies 
         run: |
           sudo apt install ninja-build
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Cross-build for ${{ matrix.arch.triple }} LLVM-${{ matrix.llvm-version}} ${{ matrix.build-type }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Install cross-compile toolchain and QEMU
         run: |
           sudo apt update
@@ -168,7 +168,7 @@ jobs:
       shell: cmd
       run: |
         dir "${{ matrix.vspath }}"
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         submodules: true
     - name: Install dependencies
@@ -224,7 +224,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - uses: msys2/setup-msys2@v2
       with:
         msystem: ${{ matrix.msystem }}
@@ -247,7 +247,7 @@ jobs:
       working-directory: build
       run: |
         cmake --install . --prefix=../dist
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: ${{matrix.os}}-${{ matrix.msystem }}-${{ matrix.build-type }}-compat-${{ matrix.strict-apple-compatibility }}
         path: dist/
@@ -272,7 +272,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Android ${{ matrix.build-type }} ${{ matrix.arch.name }} API-${{ matrix.api-level }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install Dependencies
       run: |
         sudo apt-get update -y
@@ -283,7 +283,7 @@ jobs:
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
     - name: AVD cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: avd-cache
       with:
         path: |

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -42,7 +42,7 @@ jobs:
             sudo apt install libc++-${llvm_version}-dev libc++abi-${llvm_version}-dev 
             sudo apt install libunwind-${llvm_version}-dev || true
           fi
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Install dependencies 
         run: |
           sudo apt install ninja-build


### PR DESCRIPTION
Every job logs "Node.js 20 is deprecated" and then runs actions/checkout@v3 on
Node 24 anyway, because the runners no longer carry Node 20.

The releases whose action.yml declares node24 are checkout v5, upload-artifact
v6 and cache v5, so those are the versions used here. msys2/setup-msys2@v2 and
reactivecircus/android-emulator-runner@v2 already declare node24 and are
unchanged. checkout v5 wants a runner of 2.327.1 or later and the hosted
runners are on 2.336.0. v6 moves credentials to a separate file and v7 refuses
a fork checkout for pull_request_target and workflow_run, and neither event is
used by these workflows.

Verified on a run of this branch: no job logs the deprecation, and the logs
carry checkout v5, upload-artifact v6 and cache v5. The windows jobs still fail
on this branch for the reason PR 407 fixes; on a branch carrying both changes
they pass.
