### PR TITLE
Take a per-object lock in objc_setAssociatedObject, and only to install

### DIFF
--- a/associate.mm
+++ b/associate.mm
@@ -55,6 +55,11 @@ struct reference_list
 	 */
 	mutex_t lock;
 	/**
+	 * Lock guarding the structure of the list.  Only the first reference list
+	 * in a chain uses it.
+	 */
+	ThinLock structureLock;
+	/**
 	 * Array of references.
 	 */
 	struct reference list[REFERENCE_LIST_SIZE];
@@ -140,7 +145,7 @@ static void setReference(struct reference_list *list,
 	struct reference *r = findReference(list, key);
 	if (NULL == r)
 	{
-		auto lock = acquire_locks_for_pointers(list);
+		std::lock_guard<ThinLock> lock{list->structureLock};
 		// Another thread may have installed this key since the search above.
 		r = findReference(list, key);
 		if (NULL == r)

--- a/associate.mm
+++ b/associate.mm
@@ -135,12 +135,14 @@ static void setReference(struct reference_list *list,
 		case OBJC_ASSOCIATION_ASSIGN:
 			break;
 	}
-	// While inserting into the list, we need to lock it temporarily.
+	// While inserting into the list, we need to lock it temporarily.  An
+	// existing reference is updated in place.
 	struct reference *r = findReference(list, key);
+	if (NULL == r)
 	{
 		auto lock = acquire_locks_for_pointers(list);
-		// If there's an existing reference, then we can update it, otherwise we
-		// have to install a new one
+		// Another thread may have installed this key since the search above.
+		r = findReference(list, key);
 		if (NULL == r)
 		{
 			// Search for an unused slot


### PR DESCRIPTION
setReference took the striped lock around a block whose only statement was a test for the preceding search having failed, so replacing the value of a key already present locked around nothing.

The search now decides whether the lock is taken, and a second search runs under it, so two threads no longer install two references for one key.

The lock is no longer the striped one either. lock_for_pointer discards the low 8 bits of the pointer, so two reference lists within 256 bytes take the same lock whatever the size of the table. The list now carries a ThinLock of its own, 4 bytes.

Ns per objc_setAssociatedObject on distinct objects: replacing a value 14.1 to 4.4 at 1 thread and 461.0 to 12.3 at 24; installing a reference 7313.0 to 53.7 at 24. objc_getAssociatedObject is unchanged at 2.7, ctest passes 198 of 198.

Still a draft: the duplicate key race the second search closes has no test, and the unsynchronized key read in findReference wants a memory model opinion.
