### PR TITLE
Choose the autorelease pool implementation once

### DIFF
--- a/arc.mm
+++ b/arc.mm
@@ -552,7 +552,11 @@ static inline void release(id obj)
 
 static inline void initAutorelease(void)
 {
-	if (Nil == AutoreleasePool)
+	// The pool implementation is chosen once.  A pool is pushed and popped
+	// through whichever one is in force, so a later switch would pop through
+	// the implementation that did not push.
+	static BOOL chosen;
+	if (!chosen)
 	{
 		AutoreleasePool = objc_getClass("NSAutoreleasePool");
 		if (Nil == AutoreleasePool)
@@ -574,6 +578,7 @@ static inline void initAutorelease(void)
 				                                               SELECTOR(addObject:));
 			}
 		}
+		chosen = YES;
 	}
 }
 


### PR DESCRIPTION
initAutorelease guarded its work with a test of AutoreleasePool, which stays Nil in a program that has no NSAutoreleasePool. The search was therefore repeated on every objc_autoreleasePoolPush and on every objc_autorelease of a fast ARC object, and objc_getClass hashes a string and walks the class table.

Callgrind over a loop of push and pop with no Foundation gives 516 instructions per pair, 65 percent of them in that lookup. Timed inside the process, ns per push and pop pair: 27.53 against 5.17 with no Foundation, and 5.17 either way with it, where the class is found on the first call and the guard closes. The suite passes, 198 of 198.

The implementation is now chosen once. Before this, a program that pushed an ARC pool and then loaded Foundation would switch, and pop through NSAutoreleasePool a pool the ARC path had pushed. Draft because that is a change in behaviour, and the answer may instead be that the late switch is worth keeping and only the lookup should be cached.
