### PR TITLE
Mix the whole pointer when choosing a property lock

### DIFF
--- a/spinlock.h
+++ b/spinlock.h
@@ -1,6 +1,7 @@
 #include "visibility.h"
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <mutex>
 #include <thread>
 
@@ -162,12 +163,19 @@ PRIVATE inline ThinLock spinlocks[spinlock_count];
  */
 static inline ThinLock *lock_for_pointer(const void *ptr)
 {
-	intptr_t hash = (intptr_t)ptr;
-	// Most properties will be pointers, so disregard the lowest few bits
-	hash >>= sizeof(void*) == 4 ? 2 : 8;
-	intptr_t low = hash & spinlock_mask;
-	hash >>= 16;
-	hash |= low;
+	uintptr_t hash = (uintptr_t)ptr;
+	// Every bit of the pointer reaches the index, so that two properties in one
+	// object, and objects that the allocator placed next to each other, take
+	// different locks.
+#if UINTPTR_MAX > 0xffffffffU
+	hash ^= hash >> 33;
+	hash *= 0xff51afd7ed558ccdULL;
+	hash ^= hash >> 29;
+#else
+	hash ^= hash >> 16;
+	hash *= 0x7feb352dU;
+	hash ^= hash >> 15;
+#endif
 	return spinlocks + (hash & spinlock_mask);
 }
 


### PR DESCRIPTION
lock_for_pointer shifted the low 8 bits of the pointer away before indexing the lock table, so two properties in one object, and objects the allocator placed next to each other, took the same lock of the 1024 available. With 64 byte allocation alignment 4 consecutive objects always collide. The comment above the function names both cases as the ones the hash exists to keep apart.

Every bit of the pointer now reaches the index. The cost is 3 instructions and no measurable time: 104.1 against 107.1 instructions per atomic set, and 21.8 ns either way across 5 runs in a fresh process each.

ns per atomic objc_setProperty, one value object per thread, on 32 cores. Distinct objects: 8 threads 216.2 to 31.7, 24 threads 2133.2 to 80.6. Different properties of one object: 8 threads 1870.0 to 217.9, 24 threads 13193.1 to 278.8. objc_setAssociatedObject at 24 threads goes 369.7 to 119.6, since the association path takes a lock from the same table. ctest passes 198 of 198.

Draft: the figures come from one machine, and the choice of mixing function is worth an opinion.
