### PR TITLE
Mix the whole pointer when choosing a property lock

### DIFF
--- a/spinlock.h
+++ b/spinlock.h
@@ -1,6 +1,7 @@
 #include "visibility.h"
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <mutex>
 #include <thread>
 
@@ -162,12 +163,19 @@ PRIVATE inline ThinLock spinlocks[spinlock_count];
  */
 static inline ThinLock *lock_for_pointer(const void *ptr)
 {
-	intptr_t hash = (intptr_t)ptr;
-	// Most properties will be pointers, so disregard the lowest few bits
-	hash >>= sizeof(void*) == 4 ? 2 : 8;
-	intptr_t low = hash & spinlock_mask;
-	hash >>= 16;
-	hash |= low;
+	uintptr_t hash = (uintptr_t)ptr;
+	// Every bit of the pointer reaches the index, so that two properties in one
+	// object, and objects that the allocator placed next to each other, take
+	// different locks.
+#if UINTPTR_MAX > 0xffffffffU
+	hash ^= hash >> 33;
+	hash *= 0xff51afd7ed558ccdULL;
+	hash ^= hash >> 29;
+#else
+	hash ^= hash >> 16;
+	hash *= 0x7feb352dU;
+	hash ^= hash >> 15;
+#endif
 	return spinlocks + (hash & spinlock_mask);
 }
 


### PR DESCRIPTION
lock_for_pointer shifted the pointer right by 8 before indexing the lock table, so two properties in one object, and objects the allocator placed next to each other, took the same lock of the 1024 available. The comment above the function names both cases as the ones it exists to keep apart.

Every bit of the pointer now reaches the index, through the murmur3 finalizer, and its 32 bit counterpart for 32 bit pointers.

Dropping only the bits an aligned pointer cannot use, by shifting 3 rather than 8, is not enough on its own, because the low bits are then or'ed into the high ones and how much that recovers depends on the address. Distinct indices for 16 properties, 8 bytes apart in one object: 1 of 16 before, 16 of 16 after, and shifting alone gives 8 of 16 at one heap base and 2 of 16 at another.

ns per atomic objc_setProperty on 32 cores at 24 threads, minimum of 3: different properties of one object 13123 to 285, distinct objects 1987 to 81. One thread is unchanged and the mix costs 3 instructions.

Suite passes, 198 of 198.
